### PR TITLE
Fix URLs in wiki docs.

### DIFF
--- a/wiki/about.md
+++ b/wiki/about.md
@@ -4,7 +4,7 @@ title: About
 ---
 # About CMUSphinx
 
-CMUSphinx http://cmusphinx.github.io collects over 20 years of the CMU 
+[CMUSphinx](https://cmusphinx.github.io) collects over 20 years of the CMU
 research. All advantages are hard to list, but just to name a few:
 
 *  State of art speech recognition algorithms for efficient speech recognition. 

--- a/wiki/asr/languagemodels.md
+++ b/wiki/asr/languagemodels.md
@@ -15,7 +15,7 @@ Goodman](http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.23.892 )
 A lastest trend is discriminative language models and recurrent neural-network 
 language models
 
-http://www.fit.vutbr.cz/~imikolov/rnnlm/
+<http://www.fit.vutbr.cz/~imikolov/rnnlm/>
 
 They demonstrate a good performance and a lot of interest is devoted to them.
 

--- a/wiki/asr/vad.md
+++ b/wiki/asr/vad.md
@@ -50,13 +50,12 @@ particular tuning of the computational expenses.
 
 This ends into fusion of the various systems, like the one available here:
 
-https://github.com/mvansegbroeck/vad
+<https://github.com/mvansegbroeck/vad>
 
 One of the modern fast VADs available in public is VAD from WebRTC codec, it 
 incorporates almost all the features existing:
 
-https://code.google.com/p/webrtc/source/browse/trunk/#trunk%2Fwebrtc%2Fcommon_au
-dio%2Fvad
+<https://code.google.com/p/webrtc/source/browse/trunk/#trunk%2Fwebrtc%2Fcommon_audio%2Fvad>
 
 and it's pretty reliable.
 

--- a/wiki/building.md
+++ b/wiki/building.md
@@ -8,14 +8,14 @@ layout: page
 
 Use pocketsphinx as a part of OpenEars toolkit
 
-http://www.politepix.com/openears/
+<http://www.politepix.com/openears/>
 
 
 ## Building on Android
 
 See the corresponding part of the tutorial
 
-http://cmusphinx.github.io/wiki/tutorialandroid
+<http://cmusphinx.github.io/wiki/tutorialandroid>
 
 ## Building on Raspberry Pi
 
@@ -26,4 +26,4 @@ the microphone
 
 Please checkout demo project here, modify it according to your needs:
 
-https://github.com/cmusphinx/pocketsphinx-wp-demo
+<https://github.com/cmusphinx/pocketsphinx-wp-demo>

--- a/wiki/cmubet.md
+++ b/wiki/cmubet.md
@@ -49,7 +49,7 @@ layout: page
 ### Eliminating dipthongs
 
 If you need to eliminate diphthongs (which you probably don't, unless you are 
-using [diphones](diphones)) you can use this mapping:
+using [diphones](/wiki/diphones)) you can use this mapping:
 
     AW -> AA UH
     AY -> AA IY
@@ -60,5 +60,5 @@ using [diphones](diphones)) you can use this mapping:
 
 Those substitutions result in about 1,155 diphones, about [1,052 of which are 
 present in the 4,800 most frequent spoken English words, but at vastly 
-different frequencies.](diphones)
+different frequencies.](/wiki/diphones)
 

--- a/wiki/cmudict.md
+++ b/wiki/cmudict.md
@@ -1,4 +1,4 @@
 ---
 layout: page 
 ---
-Please see http://www.speech.cs.cmu.edu/cgi-bin/cmudict
+Please see <http://www.speech.cs.cmu.edu/cgi-bin/cmudict>

--- a/wiki/develop.md
+++ b/wiki/develop.md
@@ -23,12 +23,12 @@ Alternatively, get latest code from github
 
 ## Read Documentation
 
-http://cmusphinx.github.io/wiki - Our wiki
+<http://cmusphinx.github.io/wiki> - Our wiki
 
-http://cmusphinx.github.io/doc/pocketsphinx - Pocketsphinx Doxygen 
+<http://cmusphinx.github.io/doc/pocketsphinx> - Pocketsphinx Doxygen
 Documentation
 
-http://cmusphinx.github.io/doc/sphinx4 - Sphinx4 Javadoc
+<http://cmusphinx.github.io/doc/sphinx4> - Sphinx4 Javadoc
 
 ##  Fix a bug 
 

--- a/wiki/diphones.md
+++ b/wiki/diphones.md
@@ -8,8 +8,8 @@ Diphthongs include diphones in them.
 [This list of the top 4,800 words by frequency in English 
 speech](http://ucrel.lancs.ac.uk/bncfreq/lists/2_2_spokenvwritten.txt) was used 
 with [CMUDICT](http://www.speech.cs.cmu.edu/cgi-bin/cmudict) to create the 
-following list of 1,052 diphones [without dipthongs](cmubet#eliminating 
-dipthongs) by approximate prevalence.
+following list of 1,052 diphones [without dipthongs](/wiki/cmubet#eliminating-dipthongs)
+by approximate prevalence.
 
 ![diphones](/data/diphones.png)
 

--- a/wiki/installingpythonstuff.md
+++ b/wiki/installingpythonstuff.md
@@ -7,15 +7,15 @@ This page details the things you need to install on Windows, Linux, and Mac OS
 X in order to do Python development with SphinxTrain.
 
 Note that Python is **not** currently **required** to use SphinxTrain, unless 
-you wish to use [LDA and MLLT feature transforms](LDAMLLT).  However, 
+you wish to use [LDA and MLLT feature transforms](/wiki/LDAMLLT).  However,
 prototyping and research is currently being done primarily using Python.
 
 First, install Python.  For Windows and Mac OS X, the latest release can be 
-found at http://www.python.org/download/.  On Linux, it should be installed 
+found at <http://www.python.org/download/>.  On Linux, it should be installed
 with your distribution.
 
 Next, install NumPy and SciPy.  For Windows, there are binary packages at 
-http://scipy.org/Download.  On Mac OS X, you may be able to find it via 
+<http://scipy.org/Download>.  On Mac OS X, you may be able to find it via
 [Fink](http://fink.sf.net) or [DarwinPorts](http://darwinports.com/).  On 
 Linux, it should be available in most recent distributions.  On Ubuntu and 
 Debian, for instance, you can just run:
@@ -25,7 +25,7 @@ Debian, for instance, you can just run:
 
 
 If you don't have a binary package to install, then you can compile it from 
-source following the instructions on http://scipy.org/Download.
+source following the instructions on <http://scipy.org/Download>.
 
 You can also optionally install [iPython](http://ipython.scipy.org/) and 
 [matplotlib](http://matplotlib.sourceforge.net/) for enhanced interactive use 

--- a/wiki/ldamllt.md
+++ b/wiki/ldamllt.md
@@ -34,7 +34,7 @@ process for you.
 ### Required software components
 
 First, you **need** to have the necessary [Python 
-modules](InstallingPythonStuff) installed in order to do LDA and MLLT.  You 
+modules](/wiki/InstallingPythonStuff) installed in order to do LDA and MLLT.  You
 should (obviously) also have Python 2.3 or newer.  To make sure that you have 
 the necessary modules installed, make sure that you can run Python and load the 
 `numpy` and `scipy.optimize` modules:

--- a/wiki/lettertophoneme.md
+++ b/wiki/lettertophoneme.md
@@ -4,7 +4,7 @@ layout: page
 # Letter to Phoneme Conversion in CMU Sphinx-4
 
 Project progress will be also available at my personal blog at: 
-http://jsalatas.ictpro.gr/category/projects/gsoc-2012/
+<http://jsalatas.ictpro.gr/category/projects/gsoc-2012/>
 
 ## Abstract
 
@@ -150,10 +150,10 @@ Technologies (ACL-08: HLT), pp.905-913, Columbus, OH, June 2008.
 Conversion”, Speech Communication, Volume 50, Issue 5, pp. 434-451, May 2008.
 
 
-[7] http://code.google.com/p/phonetisaurus/
+[7] <http://code.google.com/p/phonetisaurus/>
 
 
-[8] http://www-i6.informatik.rwth-aachen.de/web/Software/g2p.html
+[8] <http://www-i6.informatik.rwth-aachen.de/web/Software/g2p.html>
 
 
 [9] D. Jouvet, D. Fohr, I. Illina, "Evaluating Grapheme-to-Phoneme Converters 
@@ -161,20 +161,20 @@ in Automatic Speech Recognition Context", IEE International Conference on
 Acoustics, 2012
 
 
-[10] CRF Project Page, http://crf.sourceforge.net/
+[10] CRF Project Page, <http://crf.sourceforge.net/>
 
  
 
-[11] OpenFST Library, http://www.openfst.org/twiki/bin/view/FST/WebHome
+[11] OpenFST Library, <http://www.openfst.org/twiki/bin/view/FST/WebHome>
 
  
 
 [12] Javadoc for package marytts.fst, 
-http://mary.dfki.de/javadoc/4.0.0/marytts/fst/package-summary.html
+<http://mary.dfki.de/javadoc/4.0.0/marytts/fst/package-summary.html>
 
  
 
-[13] The MARY Text-to-Speech System, http://mary.dfki.de/
+[13] The MARY Text-to-Speech System, <http://mary.dfki.de/>
 
  
 

--- a/wiki/longaudiotraining.md
+++ b/wiki/longaudiotraining.md
@@ -73,11 +73,11 @@ the task.
 ## Related Sources
 
 
-*  [1] http://developer.nvidia.com/what-cuda
+*  [1] <http://developer.nvidia.com/what-cuda>
 
-*  [2] http://liuchuan.org/pub/cuHMM.pdf
+*  [2] <http://liuchuan.org/pub/cuHMM.pdf>
 
-*  [3] http://www.cse.ucsc.edu/research/compbio/papers/samspace.pdf
+*  [3] <http://www.cse.ucsc.edu/research/compbio/papers/samspace.pdf>
 
 ## Work Update
 
@@ -214,6 +214,6 @@ Note: The computation on long audio files kept failing due to alignment error.
 Because of that the subsequent steps were skipped (or also failed) and the 
 values measured for these modules are not representative. The problem with long 
 audio alignment is addressed by a separate project (see 
-[longaudioalignment](longaudioalignment)).
+[longaudioalignment](/wiki/longaudioalignment)).
 
 --- //[Michal Krajňanský](michal.krajnansky@gmail.com) 2011/07/13 10:26//

--- a/wiki/pocketsphinx_pronunciation_evaluation.md
+++ b/wiki/pocketsphinx_pronunciation_evaluation.md
@@ -514,7 +514,7 @@ line search parameters. [Here is a paper describing a different approach to
 obtaining difficult alignments of longer 
 utterances.](http://www.danielpovey.com/files/2015_icassp_librispeech.pdf) 
 Please see also: 
-http://cmusphinx.github.io/2014/07/long-audio-aligner-landed-in-trunk/
+<http://cmusphinx.github.io/2014/07/long-audio-aligner-landed-in-trunk/>
 
 Remember that [PocketSphinx has an 
 API](http://cmusphinx.github.io/doc/pocketsphinx/) because you have the 
@@ -527,9 +527,9 @@ Two prospective student applicants (so far) for the 2017 Google Summer of Code
 ported the "What's your name" examples above to 
 [pocketsphinx.js:](https://github.com/syl22-00/pocketsphinx.js)
 
-*  https://github.com/brijmohan/iremedy ([live demo](https://brijmohan.github.io/iremedy/index.html))
+*  <https://github.com/brijmohan/iremedy> ([live demo](https://brijmohan.github.io/iremedy/index.html))
 
-*  https://github.com/SND96/pocketsphinx-scores ([live demo](https://snd96.github.io/pocketsphinx-scores/live.html))
+*  <https://github.com/SND96/pocketsphinx-scores> ([live demo](https://snd96.github.io/pocketsphinx-scores/live.html))
 
 Those require Chrome or Firefox with WebRTC (GetUserMedia) microphone audio 
 input permission.
@@ -540,65 +540,64 @@ Loukina, *et al.* (September 2015) “Pronunciation accuracy and intelligibility
 of non-native speech,” in InterSpeech-2015, the Proceedings of the Sixteenth 
 Annual Conference of the International Speech Communication Association 
 (Dresden, Germany: Educational Testing Service.) 
-http://www.oeft.com/su/pdf/interspeech2015b.pdf
+<http://www.oeft.com/su/pdf/interspeech2015b.pdf>
 
 Kibishi, et al. (May 2014) “A statistical method of evaluating the 
 pronunciation proficiency/intelligibility of English presentations by Japanese 
 speakers,” ReCALL (European Association for Computer Assisted Language 
 Learning.) doi:10.1017/S0958344014000251. 
-http://www.slp.ics.tut.ac.jp/Material_for_Our_Studies/Papers/shiryou_last/e2014-
-Paper-01.pdf
+<http://www.slp.ics.tut.ac.jp/Material_for_Our_Studies/Papers/shiryou_last/e2014-Paper-01.pdf>
 
 Ronanki, Salsman, and Bo (December 2012) “Automatic Pronunciation Evaluation 
 And Mispronunciation Detection Using CMUSphinx,” in the Proceedings of the 24th 
 International Conference on Computational Linguistics (Mumbai, India: COLING 
-2012) pp. 61-67: http://www.aclweb.org/anthology/W12-5808 Source code 
+2012) pp. 61-67: <http://www.aclweb.org/anthology/W12-5808> Source code
 repository: 
-https://sourceforge.net/p/cmusphinx/code/HEAD/tree/branches/speecheval/ Blog: 
-http://pronunciationeval.blogspot.com/
+<https://sourceforge.net/p/cmusphinx/code/HEAD/tree/branches/speecheval/> Blog:
+<http://pronunciationeval.blogspot.com/>
 
 Salsman, J. (July 2014) “Development challenges in automatic speech recognition 
 for computer assisted pronunciation teaching and language learning” in 
 Proceedings of the Research Challenges in Computer Aided Language Learning 
 Conference (Antwerp, Belgium: CALL 2014.) 
-http://talknicer.com/Salsman-CALL-2014.pdf
+<http://talknicer.com/Salsman-CALL-2014.pdf>
 
 CMUSphinx PocketSphinx tutorial: 
-http://cmusphinx.github.io/wiki/tutorialpocketsphinx
+<https://cmusphinx.github.io/wiki/tutorialpocketsphinx>
 
 Huggins-Daines, David, *et al.* (2006) "Pocketsphinx: A free, real-time 
 continuous speech recognition system for hand-held devices." Proceedings of the 
 IEEE International Conference on Acoustics, Speech and Signal Processing 
-(ICASSP) vol. 1: https://www.cs.cmu.edu/~awb/papers/ICASSP2006/0100185.pdf
+(ICASSP) vol. 1: <https://www.cs.cmu.edu/~awb/papers/ICASSP2006/0100185.pdf>
 
 PocketSphinx source code: 
-http://cmusphinx.github.io/doc/pocketsphinx/files.html
+<https://cmusphinx.github.io/doc/pocketsphinx/files.html>
 
 Russell et al. (November 1992) “Children's speech training aid,” U.S. Patent 
 5,679,001 (expired; originally issued in U.K. as “Speech training aid.”) 
-https://www.google.com/patents/US5679001
+<https://www.google.com/patents/US5679001>
 
 *Proceedings of the International Symposium on Automatic Detection of Errors in 
 Pronunciation Training,* June 6–8, 2012, KTH, Stockholm, Sweden. 
-http://www.speech.kth.se/isadept/ISADEPT-proceedings.pdf
+<http://www.speech.kth.se/isadept/ISADEPT-proceedings.pdf>
 
 *Proceedings of the Workshop on Speech and Language Technology in Education,* 
 September 4–5, 2015 (Satellite Workshop of Interspeech 2015 and the ISCA 
 Special Interest Group SLaTE) Leipzig, Germany. 
-https://www.slate2015.org/files/SLaTE2015-Proceedings.pdf
+<https://www.slate2015.org/files/SLaTE2015-Proceedings.pdf>
 
 Chen and Li (2016) "Computer-assisted pronunciation training: From 
 pronunciation scoring towards spoken language learning" *Proceedings of the 
 2016 Asian-Pacific Signal and Information Processing Association (APSIPA) 
 Annual Summit and Conference:* 
-http://www.apsipa.org/proceedings_2016/HTML/paper2016/227.pdf
+<http://www.apsipa.org/proceedings_2016/HTML/paper2016/227.pdf>
 
 Computer-Assisted Pronunciation Teaching Bibliography: 
-http://liceu.uab.es/~joaquim/applied_linguistics/L2_phonetics/CALL_Pron_Bib.html
+<http://liceu.uab.es/~joaquim/applied_linguistics/L2_phonetics/CALL_Pron_Bib.html>
 
 Panayotov, V., *et al.* (2015) ["LIBRISPEECH: An ASR Corpus Based on Public
 Domain Audio Books"](http://www.danielpovey.com/files/2015_icassp_librispeech.pdf) 
-http://www.danielpovey.com/files/2015_icassp_librispeech.pdf
+<http://www.danielpovey.com/files/2015_icassp_librispeech.pdf>
 
 Hui Jiang (2005) ["Confidence measures for speech recognition: A 
 survey,"](http://citeseerx.ist.psu.edu/viewdoc/download;jsessionid=A45729E2ECDD6F9FA3BFE8BBDEDDDE15?doi=10.1.1.93.6890&rep=rep1&type=pdf) 
@@ -607,7 +606,7 @@ survey,"](http://citeseerx.ist.psu.edu/viewdoc/download;jsessionid=A45729E2ECDD6
 ### Draft GSoC 2017 proposal
 
 Please see 
-https://en.wiktionary.org/wiki/Wiktionary:Grease_pit/2017/March#Please_comment_on_adding_pronunciation_assessment for a mocked-up example.
+<https://en.wiktionary.org/wiki/Wiktionary:Grease_pit/2017/March#Please_comment_on_adding_pronunciation_assessment> for a mocked-up example.
 
 #### Goals
 

--- a/wiki/pocketsphinxhandhelds.md
+++ b/wiki/pocketsphinxhandhelds.md
@@ -52,8 +52,8 @@ reducing the amount of computation. Basically everything is decoded with
 phonetic decoder first and then detailed search is restricted by the results of 
 the fast phonetic search. It's also called "Fast match". For details and 
 evaluations see the chapter "4.5 Phonetic Fast Match" in 
-[[http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.72.3560 | Efficient
-Algorithms for Speech Recognition Mosur K. Ravishankar]]
+[Efficient Algorithms for Speech Recognition Mosur K. Ravishankar](
+http://citeseerx.ist.psu.edu/viewdoc/summary?doi=10.1.1.72.3560)
 
 pl_window specifies lookahead distance in frames. Typical values are from 0 
 (don't use lookahead) to 10 (decode 10 frames ahead). Bigger values give faster 

--- a/wiki/postpframework.md
+++ b/wiki/postpframework.md
@@ -75,7 +75,7 @@ chuckled Billy Waldon `<PERIOD>`  He wants to show them where they get off
 ## Usage
 
 The project is available for download at 
-https://cmusphinx.svn.sourceforge.net/svnroot/cmusphinx/branches/ppf.
+<https://cmusphinx.svn.sourceforge.net/svnroot/cmusphinx/branches/ppf>.
 
 To compile the project install ant and be sure to set the required enviroment 
 variables.
@@ -123,10 +123,9 @@ MISSING FROM OUTPUT: 10802
 
  1.  [SENTENCE SEGMENTATION AND PUNCTUATION RECOVERY FOR SPOKEN LANGUAGE 
 TRANSLATION](http://www.cs.cmu.edu/~ianlane/pub/PAULIK-icassp08.pdf)
- 2.  
-[[http://peer.ccsd.cnrs.fr/docs/00/49/92/19/PDF/PEER_stage2_10.1016%252Fj.specom
-.2008.05.008.pdf|Recovering Capitalization and Punctuation
-Marks for Automatic Speech Recognition]]
+ 2.  [Recovering Capitalization and PunctuationMarks for Automatic Speech
+Recognition](http://peer.ccsd.cnrs.fr/docs/00/49/92/19/PDF/PEER_stage2_10.
+1016%252Fj.specom.2008.05.008.pdf)
  1.  [RESTORING PUNCTUATION AND CAPITALIZATION IN TRANSCRIBED 
 SPEECH](https://www.dropbox.com/s/2bwk2rf0xluziyj/RESTORING%20PUNCTUATION%20AND%
 20CAPITALIZATION%20IN%20TRANSCRIBED%20SPEECH.pdf)

--- a/wiki/semanticlanguagemodel.md
+++ b/wiki/semanticlanguagemodel.md
@@ -76,7 +76,7 @@ What relationships can be considered:
 --Java code to use WordNet--
 
 see repository below: 
-http://code.google.com/p/cmusphinx-gsoc2012/source/browse/#svn%2Ftrunk
+<http://code.google.com/p/cmusphinx-gsoc2012/source/browse/#svn%2Ftrunk>
  
 2) Method 2: Co-Occurring
 
@@ -197,10 +197,10 @@ used (see basic concepts in speech).
 - install required software: Jave SE, Ant, subversion
 - checkout Sphinx4 from SVN using Eclipse: File -> New Project -> SVN (Checkout 
 Project from SVN) -> Create a new repository location 
-(https://cmusphinx.svn.sourceforge.net/svnroot/cmusphinx/trunk/sphinx4) -> 
+(<https://cmusphinx.svn.sourceforge.net/svnroot/cmusphinx/trunk/sphinx4>) ->
 Finish
 - Setup JSAPI 1.0, see [sphinx4/doc/jsapi_setup.html]
-- setup build.xml, see http://www.lilwondermat.com/chatter/downloads/eclipse.pdf
+- setup build.xml, see <http://www.lilwondermat.com/chatter/downloads/eclipse.pdf>
 - setup demo debug and test: Project -> Properties -> Jave Build Path -> Source 
 -> sphinx4/src/apps (Double click Included: All) -> Add Multiple (select edu 
 subfold) in Inclusion patterns
@@ -284,8 +284,7 @@ Mathematics and Its Applications Workshop, 2000
 analysis. Discourse Processes, 25, 259–284, 1998
 
 [5] Latent Semantic Analysis (LSA) Tutorial, 
-http://www.puffinwarellc.com/index.php/news-and-articles/articles/33-latent-sema
-ntic-analysis-tutorial.html
+<http://www.puffinwarellc.com/index.php/news-and-articles/articles/33-latent-semantic-analysis-tutorial.html>
 
 [6] H. Erdogan, R. Sarikaya, S. F. Chen, Y. Gao, and M. Picheny,  Using 
 semantic analysis to improve speech recognition performance,  Comput. Speech 

--- a/wiki/speakerdiarization.md
+++ b/wiki/speakerdiarization.md
@@ -16,8 +16,8 @@ both of these - in fact it is not very useful to do one without the other.
 ### Getting Started
 
 First, download the LIUM_spkDiarization .jar file from 
-http://liumtools.univ-lemans.fr//index.php?option=com_content&task=blogcategory&
-id=32&Itemid=60.  Running it without arguments will print out a summary of its 
+<http://liumtools.univ-lemans.fr//index.php?option=com_content&task=blogcategory&id=32&Itemid=60>.
+Running it without arguments will print out a summary of its
 options, which looks like this:
 
 `<file>`

--- a/wiki/speechdata.md
+++ b/wiki/speechdata.md
@@ -7,20 +7,20 @@ The possible sources of speech data:
 
 ## Acoustic Data
 
-http://voxforge.org/
+<http://voxforge.org/>
 
 
 TEDLIUM:
 
-http://www-lium.univ-lemans.fr/en/content/corpus
+<http://www-lium.univ-lemans.fr/en/content/corpus>
 
 CSTR VSTK:
 
-http://homepages.inf.ed.ac.uk/jyamagis/page3/page58/page58.html
+<http://homepages.inf.ed.ac.uk/jyamagis/page3/page58/page58.html>
 
 Librivox:
 
-http://librivox.org
+<http://librivox.org>
 
 ## Text data
 

--- a/wiki/sphinxinaction.md
+++ b/wiki/sphinxinaction.md
@@ -117,10 +117,10 @@ sphinx4 applied for MaxMSP.
 SphinxSpeech](https://forge.openinterface.org/projects/sphinxspeech/ ) - 
 OpenInterface project using Sphinx.
 
-*  https://github.com/alumae/ruby-pocketsphinx-server - HTTP server 
+*  <https://github.com/alumae/ruby-pocketsphinx-server> - HTTP server
 transcribing requests in Ruby
 
-*  https://github.com/watsonbox/pocketsphinx-ruby - pocketsphinx Ruby bindings 
+*  <https://github.com/watsonbox/pocketsphinx-ruby> - pocketsphinx Ruby bindings
 created with FFI
 
 ## Art Installations
@@ -134,5 +134,5 @@ for talks in public places
 
 ## Interoperation with other engines
 
-http://sourceforge.net/projects/srmc/ Speech Recognition Model Conversion (See 
+<http://sourceforge.net/projects/srmc/> Speech Recognition Model Conversion (See
 also htk2s3conv in our sources).

--- a/wiki/sphinxtrainwalkthrough.md
+++ b/wiki/sphinxtrainwalkthrough.md
@@ -36,7 +36,7 @@ the source directory (provided that you have first installed
 	>>>
 
 Some automatically-generated (and incomplete) documentation on the Python 
-modules can be found at http://lima.lti.cs.cmu.edu/pydoc/SphinxTrain/
+modules can be found at <http://lima.lti.cs.cmu.edu/pydoc/SphinxTrain/>
 
 ### Header Files
 

--- a/wiki/tutorialadapt.md
+++ b/wiki/tutorialadapt.md
@@ -28,7 +28,7 @@ to the particular speaker.
 
 The methods of adaptation are a bit different between PocketSphinx and Sphinx4 
 due to the different types of acoustic models used. For more technical 
-information on that see [acousticmodeltypes](acousticmodeltypes).
+information on that see [acousticmodeltypes](/wiki/acousticmodeltypes).
 
 ##  Creating an adaptation corpus 
 
@@ -305,9 +305,9 @@ After you have done the adaptation, it's critical to test the adaptation
 quality. To do that you need to setup the database similar to the one used for 
 adaptation. To test the adaptation you need to configure the decoding with the 
 required paramters, in particular, you need to have a language model 
-`<your.lm>`. For more details see  [tutoriallm](tutoriallm). The detailed 
+`<your.lm>`. For more details see  [tutoriallm](/wiki/tutoriallm). The detailed
 process of testing the model is covered in [other part of the 
-tutorial](tutorialtuning). 
+tutorial](/wiki/tutorialtuning).
 
 You can try to run decoder on the original acoustic model and on new acoustic 
 model to estimate the improvement.

--- a/wiki/tutorialam.md
+++ b/wiki/tutorialam.md
@@ -774,8 +774,9 @@ product for  these steps is a file, `feature_transform`,  in your
 Finally, one more step will run if you specify MMIE training with
 `$CFG_MMIE =  "yes";`. Default is `"no"`. This will run steps
 `60.lattice_generation`, `61.lattice_pruning`, `62.lattice_conversion`
-and `65.mmie_train`. For  details see [mmie_train](mmie_train). ##
-Testing
+and `65.mmie_train`. For  details see [mmie_train](/wiki/mmie_train).
+
+## Testing
 
 It's *critical* to test the quality of the trained database in order to 
 select best parameters, understand how application performs and optimize

--- a/wiki/tutorialandroid.md
+++ b/wiki/tutorialandroid.md
@@ -11,7 +11,7 @@ title: Pocketsphinx on Android
 ## Introduction
 
 Current tutorial describes a most recent version available on
-[GitHub](http///github.com/cmusphinx/pocketsphinx-android-demo).
+[GitHub](https://github.com/cmusphinx/pocketsphinx-android-demo).
 
 ## PocketSphinx Android demo
 

--- a/wiki/tutoriallmadvanced.md
+++ b/wiki/tutoriallmadvanced.md
@@ -13,7 +13,7 @@ to build the language model for that domain yourself. You can mix that specific
 domain with generic domain to get some fallback, but specific domain is still 
 needed. Generic language models are created from large texts.
 
-The language modeling toolkit is http://www.speech.sri.com/projects/srilm, it 
+The language modeling toolkit is <http://www.speech.sri.com/projects/srilm>, it
 contains most tools for language modeling. In modern systems there is a lot of 
 success with neural-network based RNNLM language models. Those are supported in 
 rnnlm toolkit.

--- a/wiki/tutorialpocketsphinx.md
+++ b/wiki/tutorialpocketsphinx.md
@@ -18,7 +18,7 @@ Linux, Windows, on MacOS, iPhone and Android.
 
 First of all, download the released packages pocketsphinx and sphinxbase from 
 project downloads, checkout them from subversion or github. For more details 
-see [ download page](download ).
+see [ download page](/wiki/download ).
 
 Unpack them into same directory. On Windows, you will need to rename 
 'sphinxbase-X.Y' (where X.Y is the SphinxBase version number) to simply
@@ -131,7 +131,7 @@ the same process.
 significant reduction in memory consumption.
 
 Reference documentation for the new API is available at 
-http://cmusphinx.github.io/doc/pocketsphinx/
+<https://cmusphinx.github.io/doc/pocketsphinx/>
 
 ## Basic Usage (hello world)
 

--- a/wiki/versions.md
+++ b/wiki/versions.md
@@ -69,5 +69,5 @@ at the online documentation.
 
 **Other Decoders**
 
-For competition with other decoders see [competition](competition)
+For competition with other decoders see [competition](/wiki/competition)
 

--- a/wiki/webdatacollection.md
+++ b/wiki/webdatacollection.md
@@ -108,7 +108,7 @@ language models for continuous speech recognition of SMS text messages”. In:
 Proceedings of the 12th Conference of the European Chapter of the Association 
 for Computational Linguistics. EACL ’09. Athens, Greece: Association for 
 Computational Linguistics, 2009, pp. 157–165. url: 
-http://dl.acm.org/citation.cfm?id=1609067.1609084.
+<http://dl.acm.org/citation.cfm?id=1609067.1609084>.
 
 [3] Xiaojin Zhu and Ronald Rosenfeld. “Improving Trigram Language Modeling with 
 the World Wide Web”. In: Acoustics, Speech, and Signal Processing, 2001. 


### PR DESCRIPTION
Performed fixes:
* convert URL-like text into clickable links;
* make broken links to other wiki pages absolute.