### PR TITLE
Update *.jsgf example for compliance with cmubet

### DIFF
--- a/wiki/pocketsphinx_pronunciation_evaluation.md
+++ b/wiki/pocketsphinx_pronunciation_evaluation.md
@@ -151,7 +151,7 @@ displacements of the vocal tract components:
     <oy> = oy | ao | iy | ay;
     <p> = p | t | b | hh;
     <r> = r | y | l;
-    <ss> = sh | s | z | th;
+    <s> = sh | s | z | th;
     <sh> = sh | s | zh | ch;
     <t> = t | ch | k | d | p | hh;
     <th> = th | s | dh | f | hh;


### PR DESCRIPTION
Founded that example uses <SS> instead of <S>. It's can make problems when grammars generates in runtime by pronunciation dictionary based on CMUBet: line 340: Undefined rule in RHS