### PR TITLE
Improve tutorial texts

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -3,7 +3,7 @@ layout: default
 ---
 <div class="post">
   <header class="post-header">
-    <h1 class="h2">{{ page.title }}</h1>
+    <h1>{{ page.title }}</h1>
   </header>
   <article class="post-content">
   {{ content }}

--- a/_sass/_posts.scss
+++ b/_sass/_posts.scss
@@ -46,3 +46,21 @@
 .related-post-title {
   border-bottom: thin solid #f3f3f3;
 }
+
+.post-bottom-nav {
+  display: flex;
+  justify-content: space-between;
+  margin-top: 2em;
+
+  a:nth-of-type(1) {
+    &:before {
+      content: "⇠ ";
+    }
+  }
+
+  a:nth-of-type(2) {
+    &:after {
+      content: " ⇢";
+    }
+  }
+}

--- a/wiki/tutorial.md
+++ b/wiki/tutorial.md
@@ -1,39 +1,35 @@
 ---
-layout: page 
-title: Tutorial For Developers
+layout: page
+title: CMUSphinx Tutorial For Developers
 ---
-# CMUSphinx Tutorial For Developers
 
 ## Introduction
 
-This manual is going to describe the applications of CMUSphinx toolkit.
-Such applications could include voice control of desktop, various
-automotive devices, intelligent houses. Other possible applications are
+This tutorial is going to describe some applications of the CMUSphinx toolkit.
+Such applications could include voice control of your desktop, various
+automotive devices and intelligent houses. Other possible applications are
 speech transcription, closed captioning, speech translation, voice
 search and language learning. If you want to create one of them,
-CMUSphinx toolkit is your choice.
+the CMUSphinx toolkit is your choice.
 
-This manual is intended for developers who need to apply speech
-technology in their applications, not for speech recognition researches.
-Its recommended to start with a textbook on speech technologies in other
-case. [ Spoken Language Processing by Acero, Huang and 
+The tutorial is intended for developers who need to apply speech
+technology in their applications, not for speech recognition researchers.
+If you are a researcher, it’s recommended to start with a textbook on speech
+technologies. [Spoken Language Processing by Acero, Huang and
 others](http://www.amazon.com/Spoken-Language-Processing-Algorithm-Development/d
-p/0130226165 ) is a good
-choice for that.
+p/0130226165 ) is a good choice for that.
 
 
-The structure is the following:
+The structure of this tutorial is the following:
 
-
-*  [ Basic concepts of speech](/wiki/tutorialconcepts )
-*  [ Overview of the CMUSphinx toolkit](/wiki/tutorialoverview )
-*  [ Before you start](/wiki/tutorialbeforestart )
-*  [ Building the application with sphinx4](/wiki/tutorialsphinx4 )
-*  [ Building the application with pocketsphinx](/wiki/tutorialpocketsphinx )
-*  [ Using pocketsphinx on Android](/wiki/tutorialandroid )
-*  [ Building the dictionary](/wiki/tutorialdict )
-*  [ Building the language model](/wiki/tutoriallm )
-*  [ Adapting existing acoustic model](/wiki/tutorialadapt )
-*  [ Building the acoustic model](/wiki/tutorialam )
-*  [ Tuning the performance](/wiki/tutorialtuning )
-
+*  [Basic concepts of speech recognition](/wiki/tutorialconcepts)
+*  [Overview of the CMUSphinx toolkit](/wiki/tutorialoverview)
+*  [Before you start](/wiki/tutorialbeforestart)
+*  [Building an application with sphinx4](/wiki/tutorialsphinx4)
+*  [Building an application with pocketsphinx](/wiki/tutorialpocketsphinx)
+*  [Using PocketSphinx on Android](/wiki/tutorialandroid)
+*  [Building a dictionary](/wiki/tutorialdict)
+*  [Building a language model](/wiki/tutoriallm)
+*  [Adapting an existing acoustic model](/wiki/tutorialadapt)
+*  [Training an acoustic model](/wiki/tutorialam)
+*  [Tuning the performance](/wiki/tutorialtuning)

--- a/wiki/tutorialadapt.md
+++ b/wiki/tutorialadapt.md
@@ -1,80 +1,85 @@
 ---
-layout: page 
-title: Adaptation of the acoustic model
+layout: page
+title: Adapting the default acoustic model
 ---
 
-**This tutorial describes version 5prealpha. It will not work in older version. 
-Please update.**
+---
+* auto-gen TOC:
+{:toc}
+---
 
-# Adapting the default acoustic model
+> **Caution!**  
+  This tutorial uses the [5 pre-alpha release](https://sourceforge.net/projects/cmusphinx/files/sphinx4/5prealpha/).  
+  It is not going to work for older versions.
 
-This page describes how to do some simple acoustic model adaptation to improve 
-speech recognition in your configuration. Please note that the adaptation 
-doesn't necessary adapt for a particular speaker. It just improves the fit 
-between the adapatation data and the model. For example you can adapt to your 
-own voice to make dictation good, but you also can adapt to your particular 
-recording environment, your audio transmission channel, your accent or accent 
-of your users. You can use model trained with clean broadcast data and 
-telephone data to produce telephone acoustic model by doing adaptation. 
-Cross-language adaptation also make sense, for example you can adapt English 
-model to sounds of other language by creating a phoneset map and creating other 
-language dictionary with English phoneset.
+This page describes how to do some simple acoustic model adaptation to improve
+speech recognition in your configuration. Please note that the adaptation
+doesn't necessary adapt for a particular speaker. It just improves the fit
+between the adaptation data and the model. For example you can adapt to your
+own voice to make dictation good, but you also can adapt to your particular
+recording environment, your audio transmission channel, your accent or accent
+of your users. You can use a model trained with clean broadcast data and
+telephone data to produce a telephone acoustic model by doing adaptation.
+Cross-language adaptation also make sense, you can for example adapt an English
+model to sounds of another language by creating a phoneset map and creating
+another language dictionary with an English phoneset.
 
-The adaptation process takes transcribed data and improves the model you 
-already have. It's more robust than training and could lead to a good results 
-even if your adaptation data is small. For example, it's enough to have 5 
-minutes of speech to significantly improve the dictation accuracy by adaptation 
+The adaptation process takes transcribed data and improves the model you
+already have. It’s more robust than training and could lead to good results
+even if your adaptation data is small. For example, it’s enough to have 5
+minutes of speech to significantly improve the dictation accuracy by adapting
 to the particular speaker.
 
-The methods of adaptation are a bit different between PocketSphinx and Sphinx4 
-due to the different types of acoustic models used. For more technical 
-information on that see [acousticmodeltypes](/wiki/acousticmodeltypes).
+The methods of adaptation are a bit different between PocketSphinx and Sphinx4
+due to the different types of acoustic models used. For more technical
+information on that read the article about
+[Acoustic Model Types](/wiki/acousticmodeltypes).
 
-##  Creating an adaptation corpus 
+##  Creating an adaptation corpus
 
-The first thing you need to do is create a corpus of adaptation data.  This 
-will consist of a list of sentences, a dictionary describing the pronunciation 
-of all the words in that list of sentences, and a recording of you speaking 
-each of those sentences.
+The first thing you need to do is to create a corpus of adaptation data. The
+corpus will consist of
+
+* a list of sentences
+* a dictionary describing the pronunciation of all the words in that list of sentences
+* a recording of you speaking each of those sentences
 
 ### Required files
 
-The actual set of sentences you use is somewhat arbitrary, but ideally it 
-should have good coverage of the most frequently used words or phonemes in the 
-set of sentences or the type of text you want to recognize. For example, if you 
-want to recognize isolated commands, you need tor record them. If you want to 
-recognize dictation, you need to record full sentences. For simple voice 
-adaptation we have had good results simply using sentences from the [CMU 
-ARCTIC](http://festvox.org/cmu_arctic/) text-to-speech databases.  To that 
-effect, here are the first 20 sentences from ARCTIC, a fileids file, and a 
-transcription file
+The actual set of sentences you use is somewhat arbitrary, but ideally it
+should have good coverage of the most frequently used words or phonemes in the
+set of sentences or the type of text you want to recognize. For example, if you
+want to recognize isolated commands, you need tor record them. If you want to
+recognize dictation, you need to record full sentences. For simple voice
+adaptation we have had good results simply by using sentences from the [CMU
+ARCTIC](http://festvox.org/cmu_arctic/) text-to-speech databases. To that
+effect, here are the first 20 sentences from ARCTIC, a `.fileids` file, and a
+transcription file:
 
-
-*  [arctic20.fileids](http://cmusphinx.github.io/data/arctic20.fileids)
-*  
-[arctic20.transcription](http://cmusphinx.github.io/data/arctic20.transcri
+* [arctic20.fileids](http://cmusphinx.github.io/data/arctic20.fileids)
+* [arctic20.transcription](http://cmusphinx.github.io/data/arctic20.transcri
 ption)
 
-The sections below will refer to these files, so it would be a good idea to 
-download them now.  You should also make sure that you have downloaded and 
-compiled sphinxbase and sphinxtrain.
+The sections below will refer to these files, so, if you want to follow along we
+recommend downloading these files now. You should also make sure that you have
+downloaded and compiled sphinxbase and sphinxtrain.
 
 ### Recording your adaptation data
 
-In case you are adapting to a single speaker you can record the adaptation data 
+In case you are adapting to a single speaker you can record the adaptation data
 yourself. This is unfortunately a bit more complicated than it ought to be.  
-Basically, you need to record a single audio file for each sentence in the 
-adaptation corpus, naming the files according to the names listed in 
-`arctic20.transcription` and `arctic20.fileids`.  In addition, you will 
-**NEED TO MAKE SURE THAT YOU RECORD AT A SAMPLING RATE OF 16 KHZ (or 8 kHz if 
-you adapt a telephone model) IN MONO WITH SINGLE CHANNEL.**
+Basically, you need to record a single audio file for each sentence in the
+adaptation corpus, naming the files according to the names listed in
+`arctic20.transcription` and `arctic20.fileids`.
 
-The simplest way would be to start sound recorder like Audacity or Wavesurfer 
-and read all sentences in a big audio file. Then you can cut audio files on 
-sentences in a text editor and make sure every sentence is saved in the 
+In addition, you need to make sure that you record at a *sampling rate of
+16 kHz* (or 8 kHz if you adapt a telephone model) in *mono with a single channel*.
+
+The simplest way would be to start a sound recorder like Audacity or Wavesurfer
+and read all sentences in one big audio file. Then you can cut the audio files
+on sentences in a text editor and make sure every sentence is saved in the
 corresponding file. The file structure should look like this:
 
-	
 	arctic_0001.wav  
 	arctic_0002.wav
 	.....
@@ -82,60 +87,52 @@ corresponding file. The file structure should look like this:
 	arctic20.fileids
 	arctic20.transcription
 
-
-You should verify that these recordings sound okay.  To do this, you can play 
+You should verify that these recordings sound okay. To do this, you can play
 them back with:
 
-	
-	for i in *.wav; do play $i; done
+```bash
+for i in *.wav; do play $i; done
+```
 
+If you already have a recording of the speaker, you can split it on sentences and
+create the `.fileids` and the `.transcription` files.
 
-If you already have recording of the speaker, you can split it on sentences and 
-create fileids and transcription files.
-
-If you are adapting to a channel, accent or some other generic property of the 
-audio, then you need to collect a little bit more recordings manually. For 
-example, in call center you can record and transcribe hundred calls and use 
+If you are adapting to a channel, accent or some other generic property of the
+audio, then you need to collect a little bit more recordings manually. For
+example, in a call center you can record and transcribe hundred calls and use
 them to improve the recognizer accuracy by means of adaptation.
 
 ## Adapting the acoustic model
 
-First we will copy the default acoustic model from PocketSphinx into the 
-current directory in order to work on it. Assuming that you installed 
-PocketSphinx under `/usr/local`, the acoustic model directory is 
-`/usr/local/share/pocketsphinx/model/en-us/en-us`.  Copy this directory to 
+First we will copy the default acoustic model from PocketSphinx into the
+current directory in order to work on it. Assuming that you installed
+PocketSphinx under `/usr/local`, the acoustic model directory is
+`/usr/local/share/pocketsphinx/model/en-us/en-us`. Copy this directory to
 your working directory:
 
-	
 	cp -a /usr/local/share/pocketsphinx/model/en-us/en-us .
 
+Let’s also copy the dictionary and the langauge model for testing:
 
-Lets also copy the dictionary and the lm for the testing
-
-	
 	cp -a /usr/local/share/pocketsphinx/model/en-us/cmudict-en-us.dict .
 	cp -a /usr/local/share/pocketsphinx/model/en-us/en-us.lm.bin .
 
-
 ### Generating acoustic feature files
 
-In order to run the adaptation tools, you must generate a set of acoustic model 
-feature files from these WAV audio recordings.  This can be done with the 
-`sphinx_fe` tool from SphinxBase.  It is imperative that you make sure you 
-are using the same acoustic parameters to extract these features as were used 
-to train the standard acoustic model.  Since PocketSphinx 0.4, these are stored 
-in a file called `feat.params` in the acoustic model directory.  You can 
+In order to run the adaptation tools, you must generate a set of acoustic model
+feature files from these WAV audio recordings. This can be done with the
+`sphinx_fe` tool from SphinxBase. It is imperative that you make sure you
+are using the same acoustic parameters to extract these features as were used
+to train the standard acoustic model. Since PocketSphinx 0.4, these are stored
+in a file called `feat.params` in the acoustic model directory. You can
 simply add it to the command line for `sphinx_fe`, like this:
 
-	
 	sphinx_fe -argfile en-us/feat.params \
 	        -samprate 16000 -c arctic20.fileids \
 	       -di . -do . -ei wav -eo mfc -mswav yes
 
-
 You should now have the following files in your working directory:
 
-	
 	en-us
 	arctic_0001.mfc
 	arctic_0001.wav
@@ -150,45 +147,39 @@ You should now have the following files in your working directory:
 	cmudict-en-us.dict
 	en-us.lm.bin
 
-
 ### Converting the sendump and mdef files
 
-Some models like en-us are distributed in compressed version. Extra files 
-required for adaptation are excluded to save space. For en-us model from 
-pocketsphinx you can download the full version suitable for adaptation from the 
-downloads:
+Some models like en-us are distributed in compressed version. Extra files
+that are required for adaptation are excluded to save space. For the en-us model
+from pocketsphinx you can download the full version suitable for adaptation:
 
-[ cmusphinx-en-us-ptm-5.2.tar.gz 
+[cmusphinx-en-us-ptm-5.2.tar.gz
 ](http://sourceforge.net/projects/cmusphinx/files/Acoustic%20and%20Language%20Mo
 dels/US%20English%20Generic%20Acoustic%20Model/cmusphinx-en-us-ptm-5.2.tar.gz/do
-wnload )
+wnload)
 
-Make sure you are using the full model with the mixture_weights file present.
+Make sure you are using the full model with the `mixture_weights` file present.
 
-If mdef file inside the model is converted to binary, you will also need to 
-convert the `mdef` file from the acoustic model to the plain text format used 
-by the SphinxTrain tools.  To do this, use the `pocketsphinx_mdef_convert` 
+If the `mdef` file inside the model is converted to binary, you will also need
+to convert the `mdef` file from the acoustic model to the plain text format used
+by the SphinxTrain tools. To do this, use the `pocketsphinx_mdef_convert`
 program:
 
-	
 	pocketsphinx_mdef_convert -text en-us/mdef en-us/mdef.txt
 
-
-In downloads the mdef is already in the text form.
+In the downloads the `mdef` is already in the text form.
 
 ### Accumulating observation counts
 
-The next step in adaptation is to collect statistics from the adaptation data.  
-This is done using the `bw` program from SphinxTrain.  You should be able to 
-find `bw` tool in a sphinxtrain installation in a folder 
-`/usr/local/libexec/sphinxtrain` (or under other prefix on Linux) or in 
-`bin\Release` (in sphinxtrain directory on Windows).  Copy it to the working 
-directory along with the `map_adapt` and `mk_s2sendump` programs. 
+The next step in the adaptation is to collect statistics from the adaptation data.  
+This is done using the `bw` program from SphinxTrain. You should be able to find
+the `bw` tool in a sphinxtrain installation in the folder
+`/usr/local/libexec/sphinxtrain` (or under another prefix on Linux) or in
+`bin\Release` (in the sphinxtrain directory on Windows). Copy it to the working
+directory along with the `map_adapt` and `mk_s2sendump` programs.
 
-Now, to collect statistics, run:
+Now, to collect the statistics, run:
 
-	
-	
 	./bw \
 	 -hmmdir en-us \
 	 -moddeffn en-us/mdef.txt \
@@ -201,66 +192,60 @@ Now, to collect statistics, run:
 	 -ctlfn arctic20.fileids \
 	 -lsnfn arctic20.transcription \
 	 -accumdir .
-	
 
+Make sure the arguments in the `bw` command match the parameters in the
+`feat.params` file inside the acoustic model folder. Please note that not all
+the parameters from `feat.param` are supported by `bw`.
+`bw` for example doesn't suppport `upperf` or other feature extraction
+parameters. You only need to use parameters which are accepted, other parameters
+from `feat.params` should be skipped.
 
-Make sure the arguments in `bw` command should match the parameters in 
-`feat.params` file inside the acoustic model folder. Please note that not all 
-the parameters from `feat.param` are supported by `bw`, only a few of them. 
-`bw` for example doesn't suppport `upperf` or other feature extraction 
-params. You only need to use parameters which are accepted, other parameters 
-from `feat.params` should be skipped. 
+For example, for a continuous model you don't need to include the `svspec`
+option. Instead, you need to use just `-ts2cbfn .cont.` For semi-continuous
+models use `-ts2cbfn .semi`. If the model has a `feature_transform` file like
+the en-us continuous model, you need to add the `-lda feature_transform`
+argument to `bw`, otherwise it will not work properly.
 
-For example, for continuous model you don't need to include the `svspec` 
-option. Instead, you need to use just `-ts2cbfn .cont.` For semi-continuous 
-models use `-ts2cbfn .semi.` If model has `feature_transform` file like en-us 
-continuous model, you need to add `-lda feature_transform` argument to bw, 
-otherwise it will not work properly.
+If you are missing the `noisedict` file, you also need an extra step. Copy
+the `fillerdict` file into the directory that you choose in the `hmmdir`
+parameter and renaming it to `noisedict`.
 
-Sometimes if you miss the file `noisedict` you also need an extra step, copy 
-the `fillerdict` file into the directory that you choose in the `hmmdir` 
-parameter, renaming it to `noisedict`.
+### Creating a transformation with MLLR
 
-### Creating transformation with MLLR
+MLLR transforms are supported by pocketsphinx and sphinx4. MLLR is a cheap
+adaptation method that is suitable when the amount of data is limited. It’s a
+good idea to use MLLR for online adaptation. MLLR works best for a continuous
+model. Its effect for semi-continuous models is very limited since
+semi-continuous models mostly rely on mixture weights. If you want the best
+accuracy you can combine MLLR adaptation with MAP adaptation below. On the other
+hand, because MAP requires a lot of adaptation data it is not really practical
+to use it for continuous models. For continuous models MLLR is more reasonable.
 
-MLLR transforms are supported by pocketsphinx and sphinx4. MLLR is a cheap 
-adaptation method that is suitable when amount of data is limited. It's a good 
-idea to use MLLR for online adaptation. MLLR works best for continuous model. 
-It's effect for semi-continuous models is very limited since semi-continuous 
-models mostly relies on mixture weights. If you want best accuracy you can 
-combine MLLR adaptation with MAP adaptation below. On the other hand MAP 
-requires a lot of adaptation data, it is not really practical to use it for 
-continuous models. For continuous models MLLR is more reasonable.
-
-Next we will generate an MLLR transformation which we will pass to the decoder 
-to adapt the acoustic model at run-time. This is done with the mllr_solve 
+Next, we will generate an MLLR transformation which we will pass to the decoder
+to adapt the acoustic model at run-time. This is done with the `mllr_solve`
 program:
 
-	
 	./mllr_solve \
 	    -meanfn en-us/means \
 	    -varfn en-us/variances \
 	    -outmllrfn mllr_matrix -accumdir .
 
-
-This command will create an adaptation data file called `mllr_matrix`. Now, 
-if you wish to decode with the adapted model, simply add `-mllr mllr_matrix` 
-(or whatever the path to the mllr_matrix file you created is) to your 
+This command will create an adaptation data file called `mllr_matrix`. Now,
+if you wish to decode with the adapted model, simply add `-mllr mllr_matrix`
+(or whatever the path to the mllr_matrix file you created is) to your
 pocketsphinx command line.
 
 ### Updating the acoustic model files with MAP
 
-MAP is different adaptation method. In this case unlike for MLLR we don't 
-create a generic transform but update each parameter in the model. We will now 
-copy the acoustic model directory and overwrite the newly created directory 
-with adapted model files:
+MAP is a different adaptation method. In this case, unlike for MLLR, we don’t
+create a generic transform but update each parameter in the model. We will now
+copy the acoustic model directory and overwrite the newly created directory
+with the adapted model files:
 
-	
 	cp -a en-us en-us-adapt
 
-To do adaptation, use the `map_adapt` program:
+To apply the adaptation, use the `map_adapt` program:
 
-	
 	./map_adapt \
 	    -moddeffn en-us/mdef.txt \
 	    -ts2cbfn .ptm. \
@@ -274,55 +259,47 @@ To do adaptation, use the `map_adapt` program:
 	    -mapmixwfn en-us-adapt/mixture_weights \
 	    -maptmatfn en-us-adapt/transition_matrices
 
-
 ### Recreating the adapted sendump file
 
-If you want to save space for the model you can use sendump file supported by 
-pocketsphinx. For sphinx4 you don't need that. To recreate the `sendump` file 
-from the updated `mixture_weights` file:
+If you want to save space for the model you can use a `sendump` file which is
+supported by PocketSphinx. For Sphinx4 you don’t need that. To recreate the
+`sendump` file from the updated `mixture_weights` file run:
 
-	
 	./mk_s2sendump \
 	    -pocketsphinx yes \
 	    -moddeffn en-us-adapt/mdef.txt \
 	    -mixwfn en-us-adapt/mixture_weights \
 	    -sendumpfn en-us-adapt/sendump
 
+Congratulations! You now have an adapted acoustic model.
 
-Congratulations!  You now have an adapted acoustic model!  You can delete the 
-files `en-us-adapt/mixture_weights` and `en-us-adapt/mdef.txt` to save 
-space if you like, because they are not used by the decoder.
+The `en-us-adapt/mixture_weights` and `en-us-adapt/mdef.txt` files are not used
+by the decoder, so, if you like, you can delete them to save some space.
 
-## Other acoustic models 
+## Other acoustic models
 
-For Sphinx4, the adaptation is the same as for PocketSphinx, except that 
-sphinx4 can not read binary compressed mdef and sendump files, you need to 
-leave mdef and mixture weights.
+For Sphinx4, the adaptation is the same as for PocketSphinx, except that
+Sphinx4 can not read the binary compressed `mdef` and `sendump` files, you need
+to leave the `mdef` and the `mixture weights` file.
 
 ## Testing the adaptation
 
-After you have done the adaptation, it's critical to test the adaptation 
-quality. To do that you need to setup the database similar to the one used for 
-adaptation. To test the adaptation you need to configure the decoding with the 
-required paramters, in particular, you need to have a language model 
-`<your.lm>`. For more details see  [tutoriallm](/wiki/tutoriallm). The detailed
-process of testing the model is covered in [other part of the 
-tutorial](/wiki/tutorialtuning).
+After you have done the adaptation, it’s critical to test the adaptation
+quality. To do that you need to setup the database similar to the one used for
+adaptation. To test the adaptation you need to configure the decoding with the
+required paramters, in particular, you need to have a language model
+`<your.lm>`. For more details see the tutorial on
+[Building a Language Model](/wiki/tutoriallm). The detailed process of testing
+the model is covered in [another part of the tutorial](/wiki/tutorialtuning).
 
-You can try to run decoder on the original acoustic model and on new acoustic 
-model to estimate the improvement.
+You can try to run the decoder on the original acoustic model and on the new
+acoustic model to estimate the improvement.
 
 ## Using the model
 
-After adaptation, the acoustic model is located in  the folder
-
-	
-	en-us-adapt
-
-
+After adaptation, the acoustic model is located in the folder `en-us-adapt`.
 You need only that folder. The model should have the following files:
 
-	
 	mdef
 	feat.params
 	mixture_weights
@@ -331,53 +308,56 @@ You need only that folder. The model should have the following files:
 	transition_matrices
 	variances
 
+depending on the type of the model you trained.
 
-Depending on the type of the model you trained. 
-
-To use the model in pocketsphinx, simply put the model files to the resources 
+To use the model in PocketSphinx, simply put the model files to the resources
 of your application. Then point to it with the `-hmm` option:
 
-	
-	pocketsphinx_continuous -hmm `<your_new_model_folder>` -lm `<your_lm>` 
+	pocketsphinx_continuous -hmm `<your_new_model_folder>` -lm `<your_lm>`
 -dict `<your_dict>` -infile test.wav
 
+or with the `-hmm` engine configuration option through the `cmd_ln_init`
+function. Alternatively, you can replace the old model files with the new ones.
 
-Or with `-hmm` engine configuration option through `cmd_ln_init` function. 
-Alternatively you can replace the old model files with the new ones.
-
-To use the trained model in sphinx4, you need to update the model location in 
+To use the trained model in Sphinx4, you need to update the model location in
 the code.
 
-## Adaptation didn't improve results. Troubleshooting
+## Troubleshooting
 
-Now test your accuracy to see it's good.
+If the adaptation didn’t improve your results, first test the accuracy and make
+sure it’s good.
 
-### I have no idea where to start looking for the problem
+**I have no idea where to start looking for the problem…**
 
- 1.  test accuracy on adaptation set if it improves 
- 2.  accuracy improves on adaptation set -> check if your adaptation set match 
-with your test set
- 3.  accuracy didn't improve on adaptation set -> you made mistake during 
-adaptation
+ 1. Test whether the accuracy on the adaptation set improved
+ 2. Accuracy improved on adaptation set ⇢ check if your adaptation set matches
+ 		with your test set
+ 3. Accuracy didn't improve on adaptation set ⇢ you made a mistake during the
+	  adaptation
 
-### or how much improvement I might expect through adaptation
+**…or how much improvement I might expect through adaptation**
 
 From few sentences you should get about 10% relative WER improvement.
 
-### I'm lost
+**I’m lost about…**
 
-whether it's needing more/better training data, whether I'm not doing the 
-adaptation correctly, whether my language model is the problem here, or whether 
-there is something intrinsically wrong with my configuration
+…whether it needs more/better training data, whether I'm not doing the
+adaptation correctly, whether my language model is the problem here, or whether
+there is something intrinsically wrong with my configuration.
 
-Most likely you just ignored error messages that were printed to you. You 
-obviosly need to provide more information and give access to your experiment 
+Most likely you just ignored some error messages that were printed to you. You
+obviosly need to provide more information and give access to your experiment
 files in order to get more definite advise.
 
+## What’s next
 
-## What next
+We hope the adapted model gives you acceptable results. If not, try to improve
+your adaptation process by:
 
-We hope adapted model give you acceptable results. If not, try to improve your 
-adaptation process:
- 1.  Add more adaptation data
- 2.  Adapt your language model / use better language model
+ 1.  Adding more adaptation data
+ 2.  Adapting your language mode / using a better language model
+
+ <span class="post-bottom-nav">
+ 	[Building a language model](/wiki/tutoriallm)
+  [Training an acoustic model](/wiki/tutorialam)
+ </span>

--- a/wiki/tutorialam.md
+++ b/wiki/tutorialam.md
@@ -1,281 +1,273 @@
 ---
-layout: page 
-title: Training Acoustic Model
+layout: page
+title: Training an acoustic model for CMUSphinx
 ---
 
+---
 * auto-gen TOC:
 {:toc}
-
-# Training Acoustic Model For CMUSphinx
+---
 
 ## Introduction
 
-CMUSphinx project comes with several high-quality acoustic models. There
+The CMUSphinx project comes with several high-quality acoustic models. There
 are US English acoustic models for microphone and broadcast speech as
 well as a model for speech over a telephone. You can also use French or
 Chinese models trained on a huge amount of acoustic data. Those models
-were carefully optimized to achieve best recognition performance and
-work well for almost all applications. We spent years of our experience
-to make them perfect. Most command-and-control applications and even
-some large vocabulary applications could just use default models
-directly. 
+were carefully optimized to achieve the best recognition performance and
+work well for almost all applications. We put years of experience into
+making them perfect. Most command-and-control applications and even
+some large vocabulary applications could just use default models directly.
 
-Besides models, CMUSphinx provides ways for adaptation which is
-sufficient for most cases when more accuracy is required. Adaptation is
-known to work well when you are using different recording environments 
+Besides models, CMUSphinx provides some approaches for adaptation which should
+suffice for most cases when more accuracy is required. Adaptation is
+known to work well when you are using different recording environments
 (close-distance or far microphone or telephone channel), or when a
-slightly different accent is present (UK English or even Indian English)
-or even another language. Adaptation, for example, works well  if you
+slightly different accent (UK English or Indian English) or even another
+language is present. Adaptation, for example, works well if you
 need to quickly add support for some new language just by mapping
-acoustic model phoneset to  target phoneset with the dictionary.
+a phoneset of an acoustic model to a target phoneset with the dictionary.
 
 There are, however, applications where the current models won't work.
-For example, handwriting recognition or dictation support for another
+Such examples are handwriting recognition or dictation support for another
 language. In these cases, you will need to train your own model and this
 tutorial demonstrates how to do the training for the CMUSphinx speech
 recognition engine. Before starting with the training make sure you are
-familiar with concepts, prepared the language model and you indeed need
-to train the model and have resources to do that.
+familiar with the concepts, prepared the language model. Be sure that you
+indeed need to train the model and that you have the resources to do that.
 
 ### When you need to train
 
-  * You want to create an acoustic model for new language/dialect
-  * OR you need specialized model for small vocabulary application
-  * *AND you have plenty of data to train on*:
-    * 1 hour of recording for command and control for single speaker
-    * 5 hour of recordings of 200 speakers for command and control for many speakers
-    * 10 hours of recordings for single speaker dictation
-    * 50 hours of recordings of 200 speakers for many speakers dictation
-  * AND you have knowledge on phonetic structure of the language
-  * AND you have time to train the model and optimize parameters (1 month)
+You need to train an acoustic model if:
+
+* You want to create an acoustic model for a new language or dialect
+* OR you need a specialized model for a small vocabulary application
+* *AND you have plenty of data to train on*:
+  * 1 hour of recording for command and control for a single speaker
+  * 5 hours of recordings of 200 speakers for command and control for many speakers
+  * 10 hours of recordings for single speaker dictation
+  * 50 hours of recordings of 200 speakers for many speakers dictation
+* AND you have knowledge on the phonetic structure of the language
+* AND you have time to train the model and optimize the parameters (~1 month)
 
 ### When you don't need to train
 
-  * You need to improve accuracy - do acoustic model adaptation instead
-  * You do not have enough data - do acoustic model adaptation instead
-  * You do not have enough time 
-  * You do not have enough experience
+You don’t need to train an acoustic model if:
 
-Please note that the amounts of data listed here *are required* to train 
+* You need to improve accuracy – do acoustic model adaptation instead
+* You do not have enough data – do acoustic model adaptation instead
+* You do not have enough time
+* You do not have enough experience
+
+Please note that the amounts of data listed here *are required* to train a
 model. If you have significantly less data than listed you can not
-expect to  train a good model. For example, you *can not* train a model
+expect to train a good model. For example, you *cannot* train a model
 with 1 minute of speech data.
 
 ## Data preparation
 
-The trainer learns the parameters of the models of the sound units using
+The trainer learns the parameters for the models of the sound units using
 a set of sample speech signals. This is called a training database. A
-choice of already trained databases will  also be provided to you. 
+selection of already trained databases will also be provided to you.
 
-The database contains information required to extract statistics from
+The database contains information that is required to extract statistics from
 the speech in form of the acoustic model.
 
-The trainer needs to be told which sound units you want it to learn the 
+The trainer needs to be told which sound units you want it to learn the
 parameters of, and at least the sequence in which they occur in every
-speech signal in your  training database. This information is provided
-to the trainer through a file called the *transcript file*, in which
-the sequence of words and non-speech sounds are written exactly as they
-occurred in a speech signal, followed by a tag which can be used to 
-associate this sequence with the corresponding speech signal. 
+speech signal in your training database. This information is provided
+to the trainer through a file called the *transcript file*. It contains
+the sequence of words and non-speech sounds in the exact same order as they
+occurred in a speech signal, followed by a tag which can be used to
+associate this sequence with the corresponding speech signal.
 
-Thus, in addition to the speech signals, and transcription file the
-trainer needs to access two dictionaries, one in which legitimate words
-in the language are mapped sequences of sound units (or sub-word units),
-and another in which non-speech sounds are mapped to corresponding
-non-speech  or speech-like  sound units. We will refer to the former as
-the language *phonetic dictionary* and the latter as the *filler
-dictionary*. The trainer then looks into dictionaries, to derive the
-sequence of sound units associated with each signal and transcription.
+Thus, in addition to the speech signals and transcription file, the
+trainer needs to access two dictionaries: one in which legitimate words
+in the language are mapped to sequences of sound units (or sub-word units),
+and a another one in which non-speech sounds are mapped to corresponding
+non-speech or speech-like sound units. We will refer to the former as
+the language *phonetic dictionary*. The latter is called the *filler
+dictionary*. The trainer then looks into the dictionaries, to derive the
+sequence of sound units that are associated with each signal and transcription.
 
-
-After training, it's mandatory to run the decoder to check training
+After training, it's mandatory to run the decoder to check the training
 results. The Decoder takes a model, tests part of the database and
-reference transcriptions and estimates  the quality (WER) of the model.
+reference transcriptions and estimates the quality (WER) of the model.
 During the testing stage we use the *language model* with the
 description of the possible order of words in the language.
 
-To setup a training, first of all, you need to design a database for
-training or download an existing one. For example, you can purchase a
-database from [LDC](https://www.ldc.upenn.edu). You'll have to convert
-it to a proper format.
+To setup a training, you first need to design a training database or download
+an existing one. For example, you can purchase a database from
+[LDC](https://www.ldc.upenn.edu). You'll have to convert it into a proper format.
 
 A database should be a good representation of what speech you are going
-to  recognize. For example if you are going to recognize telephone
-speech its  preferred to use telephone recordings. If you want mobile
-speech, you should  better find mobile recordings. Speech is
-significantly different across various  recording channels. Broadcast
-news is different from telephone. Speech decoded  from mp3 is
-significantly different from the microphone recording. However, if  you
-do not have enough speech recorded in required condition you should 
-definitely use the other speech you have. For example you can use
+to recognize. For example if you are going to recognize telephone
+speech it is preferred to use telephone recordings. If you want to work with
+mobile speech, you should better find mobile recordings.
+Speech is significantly different across various recording channels.
+Broadcast news is different from a phone call. Speech decoded from mp3 is
+significantly different from a microphone recording. However, if you
+do not have enough speech recorded in the required conditions you should
+definitely use any other speech you have. For example you can use
 broadcast recordings. Sometimes it make sense to stream through the
-telephone codec to make audio similar. It's often possible to add noise
+telephone codec to equalize the audio. It's often possible to add noise
 to training data too.
 
-Database should have enough speakers recording, variety of recording 
-conditions, enough acoustic variations and all possible linguistic
-sentences. The size of the database depends on the complexity of the
-task you want to handle as mentioned above. 
+The database should have recording of enough speakers, a variety of recording
+conditions, enough acoustic variations and all possible linguistic sentences.
+As mentioned before, The size of the database depends on the complexity of the
+task you want to handle.
 
-A database should have the two parts mentioned above - training part and
-test part. Usually test part is about 1/10th of the full  data size, but
-we don't recommend you to have test data more than 4 hours of 
-recordings.
+A database should have the two parts mentioned above: a training part and a
+test part. Usually the test part is about 1/10th of the total data size, but
+we don't recommend you to have more than 4 hours of recordings as test data.
 
-The good ways to obtain a database for a new language are:
+Good approaches to obtain a database for a new language are:
 
-
-  * Manually segment audio recordings with existing transcription (podcasts, news, etc)
-  * Record your friends and family and colleagues
-  * Setup automated collection on [Voxforge](http://voxforge.org)
+* Manually segmenting audio recordings with existing transcription (podcasts, news, etc.)
+* Recording your friends and family and colleagues
+* Setting up an automated collection on [Voxforge](http://voxforge.org)
 
 You have to design database prompts and post-process the results to
-ensure that audio actually corresponds to prompts. The file structure
-for the database is:
+ensure that the audio actually corresponds to the prompts. The file structure
+for the database is the following:
 
+    ├─ etc
+    │  ├─ your_db.dic                 (Phonetic dictionary)
+    │  ├─ your_db.phone               (Phoneset file)
+    │  ├─ your_db.lm.DMP              (Language model)
+    │  ├─ your_db.filler              (List of fillers)
+    │  ├─ your_db_train.fileids       (List of files for training)
+    │  ├─ your_db_train.transcription (Transcription for training)
+    │  ├─ your_db_test.fileids        (List of files for testing)
+    │  └─ your_db_test.transcription  (Transcription for testing)
+    └─ wav
+       ├─ speaker_1
+       │   └─ file_1.wav              (Recording of speech utterance)
+       └─ speaker_2
+          └─ file_2.wav
 
-  * etc
-    * your_db.dic - *Phonetic dictionary*
-    * your_db.phone - *Phoneset file*
-    * your_db.lm.DMP - *Language model*
-    * your_db.filler - *List of fillers*
-    * your_db_train.fileids - *List of files for training*
-    * your_db_train.transcription - *Transcription for training*
-    * your_db_test.fileids - *List of files for testing*
-    * your_db_test.transcription - *Transcription for testing*
-  *  wav
-    * speaker_1
-      * file_1.wav - *Recording of speech utterance*
-    * speaker_2
-      * file_2.wav
-
-Let's go through the files and describe their format and the way to prepare 
+Let's go through the files and describe their format and the way to prepare
 them:
 
-*Fileids (your_db_train.fileids and your_db_test.fileids)* file is a
-text file  listing the names of the recordings (utterance ids) one by
-line, for example
+**\*.fileids:** The `your_db_train.fileids` and `your_db_test.fileids` files
+are text files which list the names of the recordings (utterance ids) one by
+one, for example:
 
-```	
+```
 speaker_1/file_1
 speaker_2/file_2
 ```
 
-Fileids file contains the path in a file-system relative to wav
-directory. Note  that fileids file should have no extensions for audio
-files, just the names.
+A *\*.fileids* file contains the path in a file-system relative to the *wav*
+directory. Note that a *\*.fileids* file should not include audio file
+extensions in its content, but rather just the names.
 
-*Transcription file (your_db_train.transcription and
-your_db_test.transcription)* is a text file listing the transcription
-for each audio file
-   
+**\*.transcription:** The `your_db_train.transcription` and
+`your_db_test.transcription` files are text files listing the transcription
+for each audio file:
+
 ```
 <s> hello world </s> (file_1)
 <s> foo bar </s> (file_2)
 ```
 
 It's important that each line starts with `<s>` and ends with `</s>`
-followed  by id in parentheses. Also note that parenthesis contains only
-the file,  without speaker_n directory. It's critical to have exact
-match between fileids  file and the transcription file. The number of
-lines in both should be  identical. Last part of the file id
-`(speaker1/file_1)` and the utterance id `file_1` must be the same on
-each line.
+followed by an id in parentheses. Also note that the parentheses contains only
+the file,  without the *speaker_n* directory. It's critical to have an exact
+match between the *\*.fileids* file and the *\*.transcription* file.
+The number of lines in both should be identical. The last part of the file id
+`(speaker1/file_1)` and the utterance id `file_1` must be the same on each line.
 
-Below is an example of *incorrect* fileids file for the above transcription 
-file. If you follow it, you will get an error as discussed 
-[here](https://sourceforge.net/p/cmusphinx/discussion/help/thread/278ee211/)
+Below is an example of an *incorrect* *\*.fileids* file for the above transcription
+file. If you follow it, you will get an error as discussed
+[here](https://sourceforge.net/p/cmusphinx/discussion/help/thread/278ee211/):
 
 ```
 speaker_2/file_2
 speaker_1/file_1
-//Bad! Do not create fileids file like this!
+// Bad! Do not create *.fileids files like this!
 ```
 
-*Speech recordings (wav files)* 
+**Speech recordings (*.wav files):** Your audio recordings should contain
+training audio which should match the audio you want to recognize in the end.
+In case of a mismatch you could experience a sometimes even significant drop
+of the accuracy. This means if you want to recognize continuous speech, your
+training database should record continuous speech.
+For continuous speech the optimal length for audio recordings is between 5
+seconds and 30 seconds. Very long recordings make training much harder.
+If you are going to recognize short isolated commands, your training database
+should also contain files with short isolated commands. It is better to design
+the database to recognize continuous speech from the beginning though and not
+spend your time on commands. In the end you speak continuously anyway.
+The Amount of silence in the beginning and in the end of the utterance should
+not exceed 200 ms.
 
-Audio recordings should contain training audio and that training audio
-should  match the audio you want to recognize. In case of mismatch there
-could be drop  of the accuracy, sometimes significant. For example, if
-you want to recognize  continuous speech your training database should
-record continuous speech. For  continuous speech audio files shouldn't
-be very long and shouldn't be very  short. Optimal length is not less
-than 5 seconds and not more than 30 seconds.  Very long files make
-training much harder. If you are going to recognize short  isolated
-commands, your training database should contain the files with short 
-isolated commands. It is better to design database to recognize
-continuous  speech from the beginning though and not spend your time on
-commands. In the end you speak continuously anyway. Amount of silence in
-the beginning of the utterance and in the end of the utterance should
-not exceed 0.2 second.
+Recording files must be in *MS WAV* format with a specific sample rate – 16
+kHz, 16 bit, mono for desktop application, 8kHz, 16bit, mono for telephone
+applications. It’s *critical* that the audio files have a specific format.
+Sphinxtrain does support some variety of sample rates but by default it is
+configured to train from *16khz 16bit mono* files in MS WAV format.
 
-Recording files must be in MS WAV format with specific sample rate - 16
-kHz, 16  bit, mono for desktop application, 8kHz, 16bit, mono for
-telephone  applications.  It's *critical* to have audio files in a
-specific format.  sphinxtrain does support some variety of sample rates
-but by default it's  configured to train from *16khz 16bit mono* files
-in MS WAV format. *YOU NEED TO MAKE SURE THAT YOU RECORDINGS ARE AT A
-SAMPLING RATE OF 16 KHZ (or 8 kHz if you train a telephone model) IN
-MONO WITH SINGLE CHANNEL.*
+**So, please make sure that your recordings have a *samplig rate of 16 kHz* (or 8 kHz if you train a telephone model) in *mono* with a *single channel*!**
 
-If you train from 8khz model you need to make sure you configured
-feature  extraction properly. Please note that you *CAN NOT UPSAMPLE*
-your audio, that means you can not train 16 khz model with 8khz data. 
+If you train from an 8 kHz model you need to make sure you configured the
+feature extraction properly. Please note that you *cannot upsample* your audio,
+that means you can not train 16 kHz model with 8 kHz data.
 
-Audio format mismatch is the most common training problem.
+A mismatch of the audio format is the most common training problem – make sure
+you eliminated this source of problems.
 
-*Phonetic Dictionary (your_db.dict)* should have one line per word with
-word following the phonetic transcription
-   
+**Phonetic Dictionary (your_db.dict):** should have one line per word with
+the word following the phonetic transcription:
 
-```	
+```
 HELLO HH AH L OW
 WORLD W AO R L D
 ```
 
-
-If you need to find phonetic dictionary, read Wikipedia or a book on
-phonetics.  If you are using existing  phonetic dictionary. Do not use
+If you need to find a phonetic dictionary, have a look on Wikipedia or read a
+book on phonetics. If you are using an existing phonetic dictionary do not use
 case-sensitive variants like "e" and "E". Instead, all your phones must
-be different even in case-insensitive variation.  Sphinxtrain doesn't
-support some special characters like '*' or '/' and supports most of
-others like "+" or "-" or ":" But to be safe we recommend you to use
+be different even in the case-insensitive variation. Sphinxtrain doesn’t
+support some special characters like "\*" or "/" and supports most of
+others like "+", "-" or ":". However, to be safe we recommend you to use
 alphanumeric-only phone-set.
 
-Replace special characters in the phone-set, like colons or dashes or
-tildes,  with something alphanumeric. For example, replace "a~" with
+Replace special characters in the phone-set, like colons, dashes or
+tildes, with something alphanumeric. For example, replace "a~" with
 "aa" to make it alphanumeric only. Nowadays, even cell phones have
 gigabytes of memory on board. There is no sense in trying to save space
 with cryptic special characters.
 
-There is one very important thing here. For a large vocabulary database, 
-phonetic representation is more or less known; it's simple phones
-described in any book. If you don't have a phonetic  book, you can just
-use the word's spelling and it gives very good results:
+There is one very important thing here. For a large vocabulary database,
+the phonetic representation is more or less known; it’s simple phones
+described in any book. If you don’t have a phonetic book, you can just
+use the word’s spelling and it will also give you very good results:
 
-```	
+```
 ONE O N E
 TWO T W O
 ```
 
-For small vocabulary CMUSphinx is different from other toolkits. It's
-often recommended to train word-based models for small vocabulary
-databases like digits. But it only makes sense if your  HMMs could have
-variable length. 
+For a small vocabulary CMUSphinx is different from other toolkits. It’s
+often recommended to train word-based models for a small vocabulary
+databases like digits. Yet, this only makes sense if your HMMs could have
+variable length.
 
-*CMUSphinx does not support word models.* Instead, you need to use a 
+*CMUSphinx does not support word models.* Instead, you need to use a
 word-dependent phone dictionary:
 
-```	
+```
 ONE W_ONE AH_ONE N_ONE
 TWO T_TWO UH_TWO
 NINE N_NINE AY_NINE N_END_NINE
 ```
 
 This is actually *equivalent* to word-based models and some times even
-gives  better accuracy. *Do not use  word-based models with CMUSphinx.*
+gives better accuracy. *Do not use word-based models with CMUSphinx!*
 
-*Phoneset file (your_db.phone)* should have one phone per line. The
+**Phoneset file (your_db.phone):** should have one phone per line. The
 number of  phones should match the phones used in the dictionary plus
 the special SIL phone for silence:
 
@@ -286,21 +278,22 @@ DH
 IX
 ```
 
-*Language model file (your_db.lm.DMP)* should be in ARPA format or in
-DMP format. Find our more about language models on [Language Model
-training  chapter](/wiki/tutoriallm).
+**Language model file (your_db.lm.DMP):** should be in ARPA format or in
+DMP format. Find our more about language models in the
+[Building a language model](/wiki/tutoriallm) chapter.
 
-*Filler dictionary (your_db.filler)* contains filler phones (not-covered by 
-language model non-linguistic sounds like breath, hmm or laugh). It can contain 
-just silences:
+**Filler dictionary (your_db.filler):** contains filler phones (not-covered by
+language model non-linguistic sounds like breath, "hmm" or laugh).
+It can contain just silences:
 
-```	
+```
 <s> SIL
 </s> SIL
 <sil> SIL
 ```
 
-Or filler phones if they are present in the db transcriptions:
+It can also contain filler phones if they are present in the database
+transcriptions:
 
 ```
 +um+ ++um++
@@ -308,143 +301,145 @@ Or filler phones if they are present in the db transcriptions:
 ```
 
 The sample database for training is available at [an4 database NIST's
-Sphere  audio (.sph) format](http://www.speech.cs.cmu.edu/databases/an4/an4_sphere.tar.gz), you can
-use it in following steps. If you want to play with large example,
-download TEDLIUM English acoustic database. It's about 200 hours of
-audio recordings now. 
-
+Sphere audio (.sph) format](http://www.speech.cs.cmu.edu/databases/an4/an4_sphere.tar.gz), You can use this database in the following sections. If you want to play with a
+large example, download the [TED-LIUM](http://www-lium.univ-lemans.fr/en/content/ted-lium-corpus) English
+acoustic database. It contains about 200 hours of audio recordings at present.
 
 ## Compilation of the required packages
 
 The following packages are required for training:
 
-  * sphinxbase-5prealpha
-  * sphinxtrain-5prealpha
-  * pocketsphinx-5prealpha
+* sphinxbase-5prealpha
+* sphinxtrain-5prealpha
+* pocketsphinx-5prealpha
 
 The following external packages are also required:
 
-   *  perl, for example ActivePerl on Windows
-   *  python, for example ActivePython on Windows
+*  perl, for example ActivePerl on Windows
+*  python, for example ActivePython on Windows
 
-In addition, if you download packages with a `.gz` suffix, you will need 
-`gunzip` or the equivalent to unpack them.
+In addition, if you download the packages with a `.gz` suffix, you will need
+`gunzip` or an equivalent tool to unpack them.
 
-Install the perl and python packages somewhere in your executable path, if they 
+Install the perl and python packages somewhere in your executable path, if they
 are not already there.
 
-We recommend that you train on Linux: this way you'll be able to use all
-the  features of sphinxtrain. You can also use a Windows system for
-training, in that case we recommend to  use ActivePerl.
+We recommend that you train on Linux: this way you’ll be able to use all the
+features of sphinxtrain. You can also use a Windows system for training,
+in that case we recommend to use ActivePerl.
 
-For download instructions, see [Download page](http://cmusphinx.github.io/wiki/download/).  
-Basically you need to put everything into single root folder, unzip and
+For further download instructions, see
+the [download page](http://cmusphinx.github.io/wiki/download/).
+
+Basically you need to put everything into a single root folder, unzip and
 untar them, and run `configure` and `make` and `make install` in each
 package folder. Put the database folder into this root folder as well.
-By the time you  finish this, you will have a tutorial directory with
-the following contents
+By the time you finish this, you will have a tutorial directory with
+the following contents:
 
-```	
-tutorial
-  an4
-  an4_sphere.tar.gz
-  sphinxtrain
-  sphinxtrain-5prealpha.tar.gz
-  pocketsphinx
-  pocketsphinx-5prealpha.tar.gz
-  sphinxbase
-  sphinxbase-5prealpha.tar.gz
+```
+└─ tutorial
+   ├─ an4
+   ├─ an4_sphere.tar.gz
+   ├─ sphinxtrain
+   ├─ sphinxtrain-5prealpha.tar.gz
+   ├─ pocketsphinx
+   ├─ pocketsphinx-5prealpha.tar.gz
+   ├─ sphinxbase
+   └─ sphinxbase-5prealpha.tar.gz
 ```
 
-You will need to install software as an administrator `root`. After you 
+You will need to install the software as an administrator `root`. After you
 installed the software you may need to update the system configuration
-so the system will be able to find the dynamic libraries. For example
+so that the system will be able to find the dynamic libraries, e.g.:
 
-```	
+```
 export PATH=/usr/local/bin:$PATH
 export LD_LIBRARY_PATH=/usr/local/lib
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 ```
 
-If you don't want to install into system path, you may install in your
-home  folder. In that case you can append the following option to
-`autogen.sh` script or to the `configure` script
+If you don’t want to install into your system path, you may install the packages
+in your home folder. In that case you can append the following option to the
+`autogen.sh` script or to the `configure` script:
 
 ```
 --prefix=/home/user/local
 ```
 
-Obviously the folder can be an arbitrary folder but remember to update
-the environment configuration after that. If you will find that your
-binaries fail to load dynamic libraries, something like `failed to open
-libsphinx.so.0 no such file or directory` it means that you didn't
-configure the environment  properly.
+Obviously, the folder can be an arbitrary folder, just remember to update
+the environment configuration after modifying its name. If your binaries fail
+to load dynamic libraries with an error message like `failed to open
+libsphinx.so.0 no such file or directory`, it means that you didn't
+configure the environment properly.
 
 ## Setting up the training scripts
 
-To start the training change to the database folder and run the following 
+To start the training, change to the database folder and run the following
 commands:
 
-*On Linux*
+*On Linux:*
 
 ```
 sphinxtrain -t an4 setup
 ```
 
-*On Windows*
+*On Windows:*
 
-```	
+```
 python ../sphinxtrain/scripts/sphinxtrain -t an4 setup
 ```
 
-Do not forget to replace an4 with your task name.
+Do not forget to replace *an4* with your task name.
 
-This will copy all the required configuration files into etc subfolder of your 
-database folder and prepare database for training, the structure after setup 
-will be:
+This will copy all the required configuration files into the *etc/* subfolder of your
+database folder and will prepare the database for training.
+The directory structure after the setup will look like this:
 
-```	
-etc
-wav
+```
+├─ etc
+└─ wav
 ```
 
-In process of training other data folders will be created, the database should 
-look like this:
+In the process of the training other data folders will be created, so that your
+database directory should look like this:
 
-```	
-etc
-feat
-logdir
-model_parameters
-model_architecture
-result
-wav
+```
+├─ etc
+├─ feat
+├─ logdir
+├─ model_parameters
+├─ model_architecture
+├─ result
+└─ wav
 ```
 
-After setup, we need to edit the configuration files in etc folder,
-there are  many variables but to get started we need to change only a
-few. First of all find the file `etc/sphinx_train.cfg`
+After this basic setup, we need to edit the configuration files in the *etc/*
+folder. There are many variables but to get started we need to change only a
+few. First of all, find the file `etc/sphinx_train.cfg`.
 
-### Setup the format of database audio
+### Setting up the format of database audio
 
-```	
+In `etc/sphinx_train.cfg` you should see the following configurations:
+
+```
 $CFG_WAVFILES_DIR = "$CFG_BASE_DIR/wav";
 $CFG_WAVFILE_EXTENSION = 'sph';
 $CFG_WAVFILE_TYPE = 'nist'; # one of nist, mswav, raw
 ```
 
-If you recorded WAV format audio, change `sph` to `wav` here and `nist` to `mswav`.
+If you recorded audio in WAV format, change `sph` to `wav` here and `nist` to
+`mswav`:
 
-
-```	
+```
 $CFG_WAVFILES_DIR = "$CFG_BASE_DIR/wav";
 $CFG_WAVFILE_EXTENSION = 'wav';
 $CFG_WAVFILE_TYPE = 'mswav'; # one of nist, mswav, raw
 ```
 
-### Configure path to files
+### Configuring file paths
 
-See the following lines in your `etc/sphinx_train.cfg` file:
+Search for the following lines in your `etc/sphinx_train.cfg` file:
 
 ```
 # Variables used in main training of models
@@ -455,16 +450,17 @@ $CFG_LISTOFFILES    = "$CFG_LIST_DIR/${CFG_DB_NAME}_train.fileids";
 $CFG_TRANSCRIPTFILE = "$CFG_LIST_DIR/${CFG_DB_NAME}_train.transcription"
 ```
 
-These values would be already set if you set up the file structure like 
+These values would be already set if you set up the file structure like
 described earlier, but make sure that your files are really named this
-way. 
+way.
 
-The `$CFG_LIST_DIR` variable is the `/etc` directory in your project,
-and the `$CFG_DB_NAME` variable is the name of your project itself. 
+The `$CFG_LIST_DIR` variable is the `/etc` directory in your project.
+The `$CFG_DB_NAME` variable is the name of your project itself.
 
-### Configure model type and model parameters
+### Configuring model type and model parameters
 
-To select acoustic model type see [acousticmodeltypes](/wiki/acousticmodeltypes)
+To select the acoustic model type see the
+[Acoustic Model Types](/wiki/acousticmodeltypes) article.
 
 ```
 $CFG_HMM_TYPE = '.cont.'; # Sphinx4, Pocketsphinx
@@ -472,87 +468,88 @@ $CFG_HMM_TYPE = '.cont.'; # Sphinx4, Pocketsphinx
 #$CFG_HMM_TYPE  = '.ptm.'; # Sphinx4, Pocketsphinx, faster model
 ```
 
-Just uncomment what you need. For resource-efficient applications use 
+Just uncomment what you need. For resource-efficient applications use
 semi-continuous models, for best accuracy use continuous models. By
 default we use PTM models which provide a nice balance between accuracy
 and speed.
 
-```	
+```
 $CFG_FINAL_NUM_DENSITIES = 8;
 ```
 
-If you are training continuous models for large vocabulary and have more
-than  100 hours of data, put 32 here. It can be any degree of 2: 4, 8,
+If you are training continuous models for a large vocabulary and have more
+than 100 hours of data, put 32 here. It can be any power of 2: 4, 8,
 16, 32, 64.
 
 If you are training semi-continuous or PTM model, use 256 gaussians.
-	
+
 ```
 # Number of tied states (senones) to create in decision-tree clustering
 $CFG_N_TIED_STATES = 1000;
 ```
 
 This value is the number of senones to train in a model. The more
-senones model  has, the more precisely it discriminates the sounds. But
-on the other hand if  you have too many senones, model will not be
-generic enough to recognize unseen  speech. That means that the WER will
-be higher on unseen data. That's why it is  *important* to not overtrain
-the models. In case there are too many unseen senones, the warnings 
+senones a model has, the more precisely it discriminates the sounds.
+On the other hand, if you have too many senones, the model will not be
+generic enough to recognize yet unseen speech. That means that the WER will
+be higher on unseen data. That’s why it is important to *not overtrain
+the models*. In case there are too many unseen senones, the warnings
 will be generated in the norm log on stage 50 below:
 
 ```
-ERROR: "gauden.c", line 1700: Variance (mgau= 948, feat= 0, density=3, 
+ERROR: "gauden.c", line 1700: Variance (mgau= 948, feat= 0, density=3,
 component=38) is less then 0. Most probably the number of senones is too
 high for such a small training database. Use smaller $CFG_N_TIED_STATES.
 ```
 
-The approximate number of senones and number of densities for continuous
-model  is provided in the table below:
+The approximate number of senones and the number of densities for a continuous
+model is provided in the table below:
 
- | Vocabulary | Hours in db | Senones | Densities | Example |
- | 20         | 5           | 200     | 8         | Tidigits Digits Recognition |
- | 100        | 20          | 2000    | 8         | RM1 Command and Control |
- | 5000       | 30          | 4000    | 16        | WSJ1 5k Small Dictation |  
- | 20000      | 80          | 4000    | 32        | WSJ1 20k Big Dictation |  
- | 60000      | 200         | 6000    | 16        | HUB4 Broadcast News  |      
- | 60000      | 2000        | 12000   | 64        | Fisher Rich Telephone Transcription | 
+| Vocabulary |  Audio in database / hours | Senones | Densities | Example |
+| -----------|-------------|---------|-----------|---------|
+| 20         | 5           | 200     | 8         | Tidigits Digits Recognition |
+| 100        | 20          | 2000    | 8         | RM1 Command and Control |
+| 5000       | 30          | 4000    | 16        | WSJ1 5k Small Dictation |  
+| 20000      | 80          | 4000    | 32        | WSJ1 20k Big Dictation |  
+| 60000      | 200         | 6000    | 16        | HUB4 Broadcast News  |      
+| 60000      | 2000        | 12000   | 64        | Fisher Rich Telephone Transcription |
 
-For semi-continuous and PTM models use fixed number of 256 densities. 
+For semi-continuous and PTM models use a fixed number of 256 densities.
 
-Of course you also need to understand that only senones present in 
-transcription could be trained. It means that if your transcription
-isn't  generic enough, for example it's the same single word spoken by
-10000 speakers  10000 times you still have just a few senones no matter
-how many hours of  speech did you record. In that case you just need a
-few senones in the model,  not few thousands of them.
+Of course you also need to understand that only senones that are present in
+transcription can be trained. It means that if your transcription
+isn’t  generic enough, e.g. if it’s the same single word spoken by
+10.000 speakers 10.000 times you still have just a few senones no matter
+how many hours of speech you recorded. In that case you just need a
+few senones in the model, not thousands of them.
 
-It might seem that diversity could improve the model but it's not the
-case.  Diverse speech requires some artificial speech prompts and that
-decrease the  naturalness of the speech. Artificial models don't help in
-real life decoding.  In order to build a best database you need to try
-to reproduce real environment  as much as possible. It's even better to
-collect more speech to try to optimize  the database size.
+Though it might seem that diversity could improve the model that’s not the
+case. Diverse speech requires some artificial speech prompts and that
+decreases the speech naturalness. Artificial models don’t help in
+real life decoding. In order to build the best database you need to try
+to reproduce the real environment as much as possible. It’s even better to
+collect more speech to try to optimize the database size.
 
-It's important to remember, that optimal numbers *depends on your
-database*.  To train model properly, you need to experiment with
-different values and try  to select the ones which give best WER for a
-development set. You can  experiment with number of senones, number of
-Gaussian mixtures at least.  Sometimes it's also worth to experiment
-with phoneset or number of estimation  iterations.
+It’s important to remember, that *optimal numbers depend on your
+database*. To train a model properly, you need to experiment with
+different values and try to select the ones which result in the best WER for a
+development set. You can experiment with the number of senones and the number of
+Gaussian mixtures at least. Sometimes it’s also worth to experiment with
+the phoneset or the number of estimation iterations.
 
-### Configure sound feature parameters
+### Configuring sound feature parameters
 
 The default for sound files used in Sphinx is a rate of 16 thousand
-samples per second (16KHz). If this is the case, the etc/feat.params
-file will be automatically generated with the recommended values. 
+samples per second (16 KHz). If this is the case, the *etc/feat.params*
+file will be automatically generated with the recommended values.
 
-If you are using sound files with a sampling rate of 8KHz (telephone
-audio),  you need to change some values in etc/sphinx_train.cfg. The
-lower sampling rate  also means a change in the sound frequency ranges
-used and the number of  filters used to recognize speech. Recommended
+If you are using sound files with a sampling rate of 8 kHz (telephone
+audio), you need to change some values in *etc/sphinx_train.cfg*. The
+lower sampling rate also means a change in the sound frequency ranges
+and the number of filters that are used to recognize speech. Recommended
 values are:
 
-```	
+```
 # Feature extraction parameters
 $CFG_WAVFILE_SRATE = 8000.0;
 $CFG_NUM_FILT = 31; # For wideband speech it's 40, for telephone 8khz reasonable value is 31
@@ -560,51 +557,51 @@ $CFG_LO_FILT = 200; # For telephone 8kHz speech value is 200
 $CFG_HI_FILT = 3500; # For telephone 8kHz speech value is 3500
 ```
 
-### Configure parallel jobs to speedup the training
+### Configuring parallel jobs to speedup the training
 
-If you are on multicore machine or in PBS cluster you can run training
-in parallel, the following options should do the trick:
+If you are on a multicore machine or in a PBS cluster you can run the training
+in parallel. The following options should do the trick:
 
-```	
+```
 # Queue::POSIX for multiple CPUs on a local machine
 # Queue::PBS to use a PBS/TORQUE queue
 $CFG_QUEUE_TYPE = "Queue";
 ```
 
-Change type to "Queue::POSIX" to run on multicore. Then change number of 
+Change the type to "Queue::POSIX" to run on multicore. Then change the number of
 parallel processes to run:
 
-```	
+```
 # How many parts to run Forward-Backward estimation in
 $CFG_NPART = 1;
 $DEC_CFG_NPART = 1; #  Define how many pieces to split decode in
 ```
 
-If you are running on 8 core machine start around 10 parts to fully load the 
+If you are running on an 8-core machine start around 10 parts to fully load the
 CPU during training.
 
-### Configure decoding parameters
+### Configuring decoding parameters
 
-Open `etc/sphinx_train.cfg`, make sure the following is properly configured:
+Open `etc/sphinx_train.cfg` and make sure the following configurations are set:
 
-```	
+```
 $DEC_CFG_DICTIONARY     = "$CFG_BASE_DIR/etc/$CFG_DB_NAME.dic";
 $DEC_CFG_FILLERDICT     = "$CFG_BASE_DIR/etc/$CFG_DB_NAME.filler";
 $DEC_CFG_LISTOFFILES    = "$CFG_BASE_DIR/etc/${CFG_DB_NAME}_test.fileids";
 $DEC_CFG_TRANSCRIPTFILE = "$CFG_BASE_DIR/etc/${CFG_DB_NAME}_test.transcription";
 $DEC_CFG_RESULT_DIR     = "$CFG_BASE_DIR/result";
-	
-# These variables, used by the decoder, have to be user defined, and
-# may affect the decoder output
-	
+
+# These variables are used by the decoder and have to be defined by the user.
+# They may affect the decoder output.
+
 $DEC_CFG_LANGUAGEMODEL  = "$CFG_BASE_DIR/etc/${CFG_DB_NAME}.lm.DMP";
 ```
 
-If you are training with an4 please make sure that you changed 
-${CFG_DB_NAME}.lm.DMP to an4.ug.lm.DMP since the name of the language
-model is  different in an4 database.
+If you are training with *an4* please make sure that you changed
+*${CFG_DB_NAME}.lm.DMP* to *an4.ug.lm.DMP* since the name of the language
+model is different in an4 database:
 
-```	
+```
 $DEC_CFG_LANGUAGEMODEL  = "$CFG_BASE_DIR/etc/an4.ug.lm.DMP";
 ```
 
@@ -620,52 +617,53 @@ cd an4
 
 To train, just run the following commands:
 
-*On Linux*
+*On Linux:*
 
 ```
 sphinxtrain run
 ```
 
-*On Windows*
+*On Windows:*
 
 ```
 python ../sphinxtrain/scripts/sphinxtrain run
 ```
 
 and it will go through all the required stages. It will take a few
-minutes to  train. On large databases, training could take a month. 
+minutes to train. On large databases, training could take up to a month.
 
-During the stages, the most important stage is the first one which
-checks that  everything is configured correctly and your input data is
-consistent. *Do not ignore the errors reported on the first
-00.verify_all step.*
+The most important stage is the first one which checks that everything is
+configured correctly and your input data is consistent.
+
+*Do not ignore the errors reported on the first 00.verify_all step!*
 
 The typical output during decoding will look like:
 
-```	
+```
 Baum Welch starting for 2 Gaussian(s), iteration: 3 (1 of 1)
-0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
 Normalization for iteration: 3
 Current Overall Likelihood Per Frame = 30.6558644286942
 Convergence Ratio = 0.633864444461992
 Baum Welch starting for 2 Gaussian(s), iteration: 4 (1 of 1)
-0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100% 
+0% 10% 20% 30% 40% 50% 60% 70% 80% 90% 100%
 Normalization for iteration: 4
 ```
 
-These scripts process all required steps to train the model. Training is 
-complete.
+These scripts process all required steps to train the model. After they
+finished, the training is complete.
 
-## Training Internals
+## Training internals
 
-This section describes what happens during the training. In the scripts 
-directory (`./scripts_pl`), there are several directories numbered 
-sequentially from 00 through 99. Each directory either has a directory
-named `slave*.pl` or it has a single file with extension `.pl`. The
-script sequentially goes through the directories and executes either
-the the `slave*.pl` or the single `.pl` file, as below. 
+This section describes in detail what happens during the training.
 
-```	
+In the scripts directory (`./scripts_pl`), there are several directories
+numbered sequentially from *00* through *99*. Each directory either has a
+directory named `slave*.pl` or it has a single file with the extension `.pl`.
+The script sequentially goes through the directories and executes either the
+`slave*.pl` or the single `.pl` file, as below.
+
+```
 perl scripts_pl/000.comp_feat/slave_feat.pl
 perl scripts_pl/00.verify/verify_all.pl
 perl scripts_pl/10.vector_quantize/slave.VQ.pl
@@ -677,132 +675,139 @@ perl scripts_pl/50.cd_hmm_tied/slave_convg.pl
 perl scripts_pl/90.deleted_interpolation/deleted_interpolation.pl
 ```
 
-Scripts launch jobs on your machine, and the jobs will take a few
+These scripts launch jobs on your machine, and the jobs will take a few
 minutes each to run through.
- 
-Before you run any script, note the directory contents of your current 
-directory. After you run each slave.pl note the contents again. Several
-new directories  will have been created. These directories contain
-files which are being generated in the course of your training. At
-this point you need not know about the contents of these directories,
-though some of the  directory names may be self explanatory and you may
-explore them if you are  curious.
 
-One of the files that appears in your current directory is an .html
-file, named  an4.html, depending  on which database you are using. This
-file will contain a status report of jobs  already executed. Verify that
+Before you run any script, note the directory contents of your current
+directory. After you run each `slave.pl` look at the the contents again.
+Several new directories  will have been created. These directories contain
+files which are being generated in the course of your training.
+At this point you don’t need to know about the contents of these directories,
+though some of the directory names may be self-explanatory and you may
+explore them if you are curious.
+
+One of the files that appears in your current directory is an *.html*
+file, named *an4.html*, depending  on which database you are using. This
+file will contain a status report of the already executed jobs. Verify that
 the job you launched completed successfully. Only then launch the next
-slave.pl in the  specified sequence. Repeat this process until you have
-run the slave.pl in all directories.
+*slave.pl* in the specified order. Repeat this process until you have
+run the *slave.pl* in all directories.
 
-Note that in the process of going through the scripts in 00 through 90,
+Note that in the process of going through the scripts from 00 to 90,
 you will have generated  several sets of acoustic models, each of which
 could be used for recognition. Notice also that some of the steps are
 required only for the creation of semi-continuous models. If you execute
-these steps while creating continuous models, the scripts will  benignly
-do nothing. 
+these steps while creating continuous models, the scripts will benignly
+do nothing.
 
-On the stage `000.comp_feat` the feature files are extracted. The system
+In the stage `000.comp_feat` the feature files are extracted. The system
 does not directly work with acoustic signals. The signals are first
 transformed into a sequence of feature vectors, which are used in place
-of the actual acoustic  signals.
+of the actual acoustic signals.
 
-This script slave_feat.pl will compute, for each training utterance, a
-sequence of 13-dimensional vectors (feature vectors) consisting of the
-Mel-frequency cepstral coefficients (MFCCs). Note that the list of wave
-files contains a list with the full paths to the audio files. Since the
-data are all located in  the same directory as you are working, the
-paths are relative, not absolute. You may have to change this, as well
-as the an4_test.fileids file, if the location of data is different. The
-MFCCs will be placed automatically in a directory called `feat`. Note
-that the type of features vectors you compute  from the speech signals
+This script `slave_feat.pl` will compute a sequence of 13-dimensional vectors
+(feature vectors) for each training utterance consisting of the
+Mel Frequency Cepstral Coefficients
+([MFCCs](https://de.wikipedia.org/wiki/Mel_Frequency_Cepstral_Coefficients)).
+Note that the list of wave files contains a list with the full paths to the
+audio files. Since the data is all located in the same directory as your working
+directory, the paths are relative, not absolute. If the location of data is
+different, you may have to change this, as well as the *an4_test.fileids* file.
+The MFCCs will be placed automatically in a directory called `feat`.
+Note that the type of features vectors you compute from the speech signals
 for training and recognition, outside of this tutorial, is not
-restricted to MFCCs. You could use any reasonable parameterization 
+restricted to MFCCs. You could use any reasonable parameterization
 technique instead, and compute features other than MFCCs. CMUSphinx can
 use features of any type or dimensionality. The format of the features
-is described on the page [MFC Format](/wiki/mfcformat).
+is described on the [MFC Format](/wiki/mfcformat) page.
 
 Once the jobs launched from `20.ci_hmm` have run to completion, you will
-have trained the Context-Independent (CI) models for the sub-word units
-in your dictionary. 
+have trained the *Context-Independent* (CI) models for the sub-word units
+in your dictionary.
 
 When the jobs launched from the `30.cd_hmm_untied` directory run to
-completion, you will have trained the models for  Context-Dependent
+completion, you will have trained the models for *Context-Dependent*
 sub-word units (triphones) with untied states. These are called
-CD-untied models and are  necessary for building decision  trees in
-order to tie states. 
+*CD-untied models* and are necessary for building decision trees in
+order to tie states.
 
-The jobs in `40.buildtrees` will build decision trees for each state of 
-each sub-word unit. 
+The jobs in `40.buildtrees` will build decision trees for each state of
+each sub-word unit.
 
-The jobs in `45.prunetree` will prune the decision trees and tie the
-states. 
+The jobs in `45.prunetree` will prune the decision trees and tie the states.
 
 Following this, the jobs in `50.cd-hmm_tied` will train the final models
-for the triphones in your training corpus. These are called CD-tied
-models. The CD-tied models are trained in many stages. We begin with 1
-Gaussian per state HMMs, following which we train 2 Gaussian per state 
-HMMs and so on till the desired number of Gaussians per State have been 
-trained. The jobs in 50.cd-hmm_tied will automatically train all these
-intermediate CD-tied models.
- 
-At the end of any stage you may use the models for recognition. Remember
-that you may decode even while the training is in progress, provided
-you are certain  that you have crossed the stage which generates the
-models you want to decode  with. 
+for the triphones in your training corpus. These are called *CD-tied models*.
+The CD-tied models are trained in many stages. We begin with 1 Gaussian per
+state HMMs, followed by training 2 Gaussian per state HMMs and so on till the
+desired number of Gaussians per State have been trained.
+The jobs in `50.cd-hmm_tied` will automatically train all these intermediate
+CD-tied models.
 
-### Transformation Matrix Training (advanced)
+At the end of any stage you may use the models for recognition. Remember
+that you may decode even while the training is in progress, provided you are
+certain that you have crossed the stage which generates the models you want to
+decode  with.
+
+### Transformation matrix training (advanced)
 
 Some additional scripts will be launched if you choose to run them.
-These  additional training steps can be costly in computation, but
-improve recognition  rate.
+These additional training steps can be costly in computation, but improve the
+recognition rate.
 
-Transform matrices might help the training and recognition
-process in  some circumstances.
+Transform matrices might help the training and recognition process in some
+circumstances.
 
-The following steps will run if you specify `$CFG_LDA_MLLT = 'yes';` in
-the  file `sphinx_train.cfg`. If you specify 'no', the default, the
-steps will do nothing. Step  `01.lda_train` will estimate LDA matrix and
-step `02.mllt_train` will estimate MLLT matrix.
+The following steps will run if you specify
 
-The perl scripts, in turn, set up and run python modules.  The end
-product for  these steps is a file, `feature_transform`,  in your
-`model_parameters` directory. For details see [ldamllt](/wiki/ldamllt)
+```
+$CFG_LDA_MLLT = 'yes';
+```
 
-### MMIE Training (advanced)
+in the  file `sphinx_train.cfg`. If you specify `'no'` (which is the default),
+the steps will do nothing. The Step `01.lda_train` will estimate a LDA matrix
+and the step `02.mllt_train` will estimate a MLLT matrix.
 
-Finally, one more step will run if you specify MMIE training with
-`$CFG_MMIE =  "yes";`. Default is `"no"`. This will run steps
-`60.lattice_generation`, `61.lattice_pruning`, `62.lattice_conversion`
-and `65.mmie_train`. For  details see [mmie_train](/wiki/mmie_train).
+The Perl scripts, in turn, set up and run Python modules. The end product for
+these steps is a `feature_transform` file,  in your `model_parameters` directory.
+For details see the page for [Training with LDA and MLLT](/wiki/ldamllt).
+
+### MMIE training (advanced)
+
+Finally, one more step will run if you specify MMIE training by setting:
+
+```
+$CFG_MMIE =  "yes";
+```
+The default value is `"no"`. This will run steps `60.lattice_generation`, `61.lattice_pruning`, `62.lattice_conversion` and `65.mmie_train`.
+For details see the page about [MMIE Training in SphinxTrain](/wiki/mmie_train).
 
 ## Testing
 
-It's *critical* to test the quality of the trained database in order to 
-select best parameters, understand how application performs and optimize
-performance. To do that, a test decoding step is needed.  The decoding
+It's *critical* to test the quality of the trained database in order to
+select the best parameters, understand how your application performs and
+optimize the performance. To do that, a test decoding step is needed. The decoding
 is now a last stage of the training process.
 
 You can restart decoding with the following command:
 
-```	
+```
 sphinxtrain -s decode run
 ```
 
-This command will start a decoding process using the acoustic model  you 
-trained and the language model you configured in the
-`etc/sphinx_train.cfg` file. 
+This command will start a decoding process using the acoustic model you
+trained and the language model you configured in the `etc/sphinx_train.cfg` file.
 
-```	
+```
 MODULE: DECODE Decoding using models previously trained
-Decoding 130 segments starting at 0 (part 1 of 1) 
-0% 
+Decoding 130 segments starting at 0 (part 1 of 1)
+0%
 ```
 
 When the recognition job is complete, the script computes the
-recognition Word  Error Rate (WER) and  Sentence Error Rate (SER). The
-lower those rates the better for you. For  typical 10-hours task WER
-should be around 10%. For a large task, it could be like 30%.
+recognition Word Error Rate (WER) and the  Sentence Error Rate (SER).
+The lower those rates the better is your recognition. For a typical 10-hours
+task the WER should be around 10%. For a large task, it could be like 30%.
 
 On an4 data you should get something like:
 
@@ -810,12 +815,12 @@ On an4 data you should get something like:
 SENTENCE ERROR: 70.8% (92/130)   WORD ERROR RATE: 30.3% (233/773)
 ```
 
-You can find exact details of the decoding, like alignment with
-reference  transcription, speed  and result for each file, in `result`
-folder which will be created after  decoding. Look into the file
-`an4.align`:
+You can find exact details of the decoding, like the alignment with
+a reference transcription, speed and the result for each file, in the `result`
+folder which will be created after decoding.
+Let’s have a look into the file `an4.align`:
 
-```	
+```
 p   I   T      t   s   b   u   r   g   H      (MMXG-CEN5-MMXG-B)
 p   R   EIGHTY t   s   b   u   r   g   EIGHT  (MMXG-CEN5-MMXG-B)
 Words: 10 Correct: 7 Errors: 3 Percent correct = 70.00% Error = 30.00% Accuracy = 70.00%
@@ -828,25 +833,27 @@ TOTAL Words: 773 Correct: 587 Errors: 234
 TOTAL Percent correct = 75.94% Error = 30.27% Accuracy = 69.73%
 TOTAL Insertions: 48 Deletions: 15 Substitutions: 171
 ```
-For description of WER see our [Basic concepts of speech](/wiki/tutorialconcepts) chapter.
+
+For a description of the WER see our
+[Basic concepts of speech](wiki/tutorialconcepts/#what-is-optimized) chapter.
 
 ## Using the model
 
-After training, the acoustic model is located in 
+After training, the acoustic model is located in
 
-```	
+```
 model_parameters/`<your_db_name>`.cd_cont_`<number_of senones>`
 ```
 
-or in 
+or in
 
-```	
+```
 model_parameters/`<your_db_name>`.cd_semi_`<number_of senones>`
 ```
 
 You need only that folder. The model should have the following files:
 
-```	
+```
 mdef
 feat.params
 mixture_weights
@@ -856,125 +863,132 @@ transition_matrices
 variances
 ```
 
-Depending on the type of the model you trained. To use the model in 
-pocketsphinx, simply point to it with the -hmm option:
+depending on the type of the model you trained. To use the model in PocketSphinx,
+simply point to it with the `-hmm` option:
 
-```	
+```
 pocketsphinx_continuous -hmm `<your_new_model_folder>` -lm `<your_lm>` -dict `<your_dict>`.
 ```
 
-To use the trained model in sphinx4, you need to specify the path in 
-`Configuration` object
-	
-```	     
+To use the trained model in Sphinx4, you need to specify the path in the
+`Configuration` object:
+
+```java
 configuration.setAcousticModelPath("file:model_parameters/db.cd_cont_200");
 ```
 
-If the model is in resources you can reference it with resource: URL
+If the model is in the resources you can reference it with `resource:URL`:
 
-```	     
+```java
 configuration.setAcousticModelPath("resource:/com/example/db.cd_cont_200");
 ```
 
-See [Sphinx4 tutorial](/wiki/tutorialsphinx4) for details.
+See the [Sphinx4 tutorial](/wiki/tutorialsphinx4) for details.
 
 ## Troubleshooting
 
 Troubleshooting is not rocket science. For all issues you may blame
-yourself.  You are most  likely the reason of failure. *Carefully* read
-the messages in the `logdir`  folder that contains detailed log of
-actions performed for each. In addition, messages are copied to  the
-file, `your_project_name.html`, which you can read in a browser.
+yourself. You are most likely the reason of failure. *Carefully* read
+the messages in the `logdir` folder that contains a detailed log for each
+performed action. In addition, messages are copied to the
+`your_project_name.html` file, which you can open and read in a browser.
 
-There are many well-working proven methods to solve issues. For example,
-try to  reduce the  training set to see in which half the problem
-appears.
+There are many well-working, proven methods to solve issues. For example,
+try to reduce the training set to see in which half the problem appears.
 
 Here are some common problems:
 
-##### WARNING: this phone (something) appears in the dictionary (dictionary file name), but not in the phone list (phone file name). 
+* **WARNING: this phone (something) appears in the dictionary (dictionary file
+  name), but not in the phone list (phone file name).**
 
-Your dictionary either contains a mistake, or you have left out a phone
-symbol  in the phone file.  You may have to delete comment lines from
-your dictionary  file. 
+  Your dictionary either contains a mistake, or you have left out a phone symbol
+  in the phone file. You may have to delete any comment lines from your
+  dictionary file.
 
-##### WARNING: This word (word) has duplicate entries in (dictionary file name). Check for duplicates.
+* **WARNING: This word (word) has duplicate entries in (dictionary file name).
+  Check for duplicates.**
 
-You may have to sort your dictionary file lines to find them. Perhaps a
-word is  defined in both upper and lower case forms.
+  You may have to sort your dictionary file lines to find them. Perhaps a word
+  is defined in both upper and lower case forms.
 
-#####  WARNING: This word: word was in the transcript file, but is not in the dictionary (transcript line) Do cases match? 
+* **WARNING: This word: word was in the transcript file, but is not in the
+  dictionary (transcript line) Do cases match?**
 
-Make sure that all the words in the transcript are in the dictionary, and that 
-they match case when they appear. Also, words in the transcript may be 
-misspelled, run together or be a number or symbol not in the dictionary.  If 
-the dictionary file is not perfectly sorted, some entries might be skipped in 
-looking for words. If you have hand-edited the dictionary file, be sure that 
-each entry is in the proper format.
+  Make sure that all the words in the transcript are in the dictionary, and that
+  they have matching cases when they appear. Also, words in the transcript may
+  be misspelled, run together or be a number or symbol that is not in the
+  dictionary. If the dictionary file is not perfectly sorted, some entries might
+  be skipped while looking for words. If you hand-edited the dictionary file, be
+  sure that each entry is in the proper format.
 
-You may have specified phones in the phone list that are not represented
-in the  words in the transcript. The trainer expects to find examples of
-each phone at  least once.
+  You may have specified phones in the phone list that are not represented in
+  the words in the transcript. The trainer expects to find examples of each
+  phone at least once.
 
-##### WARNING: CTL file, audio file name.mfc, does not exist, or is empty.
+* **WARNING: CTL file, audio file name.mfc, does not exist, or is empty.**
 
-The .mfc files are the feature files converted from the input audio
-files on  stage `000.comp_feats`. Did you skip this step? Did you add
-new audio files  without converting them? The training process expects a
-feature file to be  there, and it isn't.
+  The *.mfc* files are the feature files converted from the input audio files in
+  stage `000.comp_feats`. Did you skip this step? Did you add new audio files
+  without converting them? The training process expects a feature file to be
+  there, but it isn’t.
 
-##### Very low recognition accuracy.
+* **Very low recognition accuracy**
 
-This might happen if there is a mismatch in the audio files and the parameters 
-of training, or between the training and the testing.
+  This might happen if there is a mismatch in the audio files and the parameters
+  of training, or between the training and the testing.
 
-##### ERROR: "backward.c", line 430: Failed to align audio to transcript: final state of the search is not reached.
+* **ERROR: "backward.c", line 430: Failed to align audio to transcript: final
+  state of the search is not reached.**
 
-Sometimes audio in your database doesn't match the transcription properly. For 
-example transcription file has the line "Hello world" but in audio actually 
-"Hello hello world" is pronounced. Training process usually detects that and 
-emits this message in the logs. If there are too many such errors it most 
-likely mean you misconfigured something, for example you had a mismatch between 
-audio and the text caused by transcription reordering. If there are few errors, 
-you can ignore them. You might want to edit the transcription file to put there 
-exact word which were pronounced, in the case above you need to edit the 
-transcription file and put "Hello hello world" on corresponding line. You might 
-want to filter such prompts because they affect acoustic model quality. In that 
-case you need to enable forced alignment stage in training. To do that edit 
-sphinx_train.cfg line 
+  Sometimes audio in your database doesn’t match the transcription properly. For
+  example the transcription file has the line "Hello world" but in audio
+  actually "Hello hello world" is pronounced. The training process usually
+  detects that and emits this message in the logs. If there are too many of such
+  errors it most likely means you misconfigured something, e.g. you had a
+  mismatch between audio and the text caused by transcription reordering.
+  If there are few errors, you can ignore them. You might want to edit the
+  transcription file to put the exact word which was pronounced. In the case
+  above you need to edit the transcription file and put "Hello hello world" on
+  the corresponding line. You might want to filter such prompts because they
+  affect the quality of the acoustic model. In that case you need to enable
+  the forced alignment stage during training. To do that edit the following line in `sphinx_train.cfg`:
+  ```
+  $CFG_FORCEDALIGN = 'yes';
+  ```
+  and run the training again. It will execute stages 10 and 11 and will filter
+  your database.
 
-```
-$CFG_FORCEDALIGN = 'yes';
-```
+* **Can't open \*/\*-1-1.match word_align.pl failed with error code 65280**
 
-and run training again. It will execute stages 10 and 11 and will filter your 
-database.
+  This error occurs because the decoder did not run properly after the training.
+  First check if the correct executable is present in your `PATH`.
+  The executable shouldbe `pocketsphinx_batch` if the decoding script being used
+  is `psdecode.pl` as set by the `$DEC_CFG_SCRIPT` variable in
+  `sphinx_train.cfg`. On Linux run:
 
-##### Can't open \*/\*-1-1.match word_align.pl failed with error code 65280
+  ```
+  which pocketsphinx_batch
+  ```
 
-This error occurs because the decoder did not run properly after training. 
-First check if the correct executable (`pocketsphinx_batch` if the decoding 
-script being used is `psdecode.pl` as set by `$DEC_CFG_SCRIPT` variable in 
-`sphinx_train.cfg`) is present in `PATH`. On Linux run 
+  and see if it is located as expected. If it is not, you need to set the `PATH`
+  variable properly. Similarly on Windows, run:
 
-```	
-which pocketsphinx_batch
-```
+  ```
+  where pocketsphinx_batch
+  ```
 
-and see if it is located. If it is not, you need to set the `PATH` variable 
-properly. Similarly on Windows, run 
+  If the path to the decoding executable is set properly, read the log files in
+  `logdir/decode/` to find out other reasons for the error.
 
-```
-where pocketsphinx_batch
-```
+* **To ask for help**
 
-If the path to decoding executable is set properly, read the log files at 
-`logdir/decode/` to find out other reasons behind the error.
+  If you want to ask for help about training, try to provide the training
+  folder or at least the logdir. Pack the files into an archive and upload it
+  to a public file sharing resource. Then post the link to the resource.
+  Remember: the more information you provide the faster you will solve the
+  problem.
 
-##### To ask for help
-
-If you want to ask for help about training, try to provide the training
-folder  or at least logdir. Pack the files into archive, upload to a
-public file  sharing resource, then post the link to the resource.
-Remember, the more  information you provide the faster you will solve
-the problem.
+<span class="post-bottom-nav">
+  [Adapting an existing acoustic model](/wiki/tutorialadapt)
+  [Tuning the performance](/wiki/tutorialtuning)
+</span>

--- a/wiki/tutorialandroid.md
+++ b/wiki/tutorialandroid.md
@@ -1,73 +1,72 @@
 ---
-layout: page 
-title: Pocketsphinx on Android
+layout: page
+title: PocketSphinx on Android
 ---
 
+---
 * auto-gen TOC:
 {:toc}
+---
 
-# Pocketsphinx on Android
-
-## Introduction
-
-Current tutorial describes a most recent version available on
-[GitHub](https://github.com/cmusphinx/pocketsphinx-android-demo).
+This tutorial describes a demo app that is available on [GitHub](https://github.com/cmusphinx/pocketsphinx-android-demo).
 
 ## PocketSphinx Android demo
 
-To try the demo the best thing would be to use Android Studio. You can
-download  Android Studio IDE and sdk from the [official
-page](http://developer.android.com/sdk/index.html )
+In order to run the demo app we recommend to use Android Studio. You can
+download the Android Studio IDE and sdk from the [official
+download page](http://developer.android.com/sdk/).
 
 ### Building and running from Android Studio
 
-You can obtain the demo in IDE, select to checkout project from VCS, select 
-github and enter the [project URL](http://github.com/cmusphinx/pocketsphinx-android-demo).
+In order to obtain the demo in the IDE, please select to *checkout a project
+from VCS*, select *GitHub* and enter the project URL: <https://github.com/cmusphinx/pocketsphinx-android-demo>.
 
-Once project will be set, IDE will update and download all dependencies 
-automatically, you can just run the project.
+Once the project is set up, your IDE will update and download all dependencies
+automatically. You should now be able to run the project.
 
-After start recognizer will take some time to initialize, then it will
-wait for  a keyword "oh mighty computer". Once keyword is detected, it
-will ask you to  select the demo - "digits", "weather" or "phones". The
-digits demo recognizes  digits from 0 to 9, the weather demo recognizes
-weather forecasts and "phones"  demo demonstrates phonetic recognition.
+After starting the app the recognizer will take some time to initialize. After
+initialization it will wait for the keyword "oh mighty computer". Once this
+keyword is detected, it will ask you to select the demo – "digits", "weather"
+or "phones". The "digits" demo recognizes digits from 0 to 9, the "weather" demo
+recognizes weather forecasts and the "phones" demo demonstrates phonetic
+recognition.
 
-To try it import this project into IDE and run as usual, check logcat for 
-details if something doesn't work.
+To try a certain demo, import this project into the IDE and run it as usual.
+In case of errors please check the logcat for further details.
 
 ### Building and running from Eclipse
 
-We do not support Eclipse project anymore, please consider SDK upgrade.
+We do not support the Eclipse project anymore, please consider an SDK upgrade.
 
-### Building and running from command-line
+### Building and running from the command line
 
-You can also build with gradle build system.
+You can also build the project with the gradle build system.
 
-  1. Clone from Github [pocketsphinx android demo source code](http://github.com/cmusphinx/pocketsphinx-android-demo).
-  1. Attach your physical device or setup a virtual device.
-  1. Create a file local.properties to point to sdk folder: `sdk.dir = /home/user/android/sdk`
-  1. Run `gradle installDebug` It will build and install the application on the device.
-  1. Manually run the application from the device application menu.
+1. Clone the repo from Github:  
+   `git clone https://github.com/cmusphinx/pocketsphinx-android-demo.git`.
+2. Attach your physical device or setup a virtual device.
+3. Create a file `local.properties` to point to sdk folder:  
+   `sdk.dir = /home/user/android/sdk`.
+4. Run `gradle installDebug`. It will build and install the application on the device.
+5. Manually run the application from the device application menu.
 
 ## Using pocketsphinx-android
 
-### Referencing the library in Android project
+### Referencing the library in an Android project
 
-Library is distributed as an 
-[AAR](https://developer.android.com/studio/projects/android-library.html) 
-archive which includes both binary so files for different architectures and 
-independent java code.
+The library is distributed as an Adroid Archive ([AAR](https://developer.android.com/studio/projects/android-library.html))
+which includes both the binary so files for different architectures and
+independent Java code.
 
-In Android Studio you need to include AAR into your project. Just go to File > 
-New > New module and choose Import .JAR/.AAR Package.
+In Android Studio you need to include the AAR into your project. Just go to
+*File > New > New module* and choose *Import .JAR/.AAR Package*.
 
-You can also add AAR to your project in command line as described in 
-[stackoverflow answer](http://stackoverflow.com/questions/21882804/adding-local-aar-files-to-my
+You can also add the AAR to your project using the command line as described in
+[this stackoverflow post](http://stackoverflow.com/questions/21882804/adding-local-aar-files-to-my
 -gradle-build).
 
-Once the AAR is imported into the project as a module, make sure it is listed as a dependency of
-a main module in app/build.gradle:
+Once the AAR is imported as module into the project, make sure it is listed as
+a dependency of a main module in `app/build.gradle`:
 
 ```
 dependencies {
@@ -77,10 +76,10 @@ dependencies {
 
 ### Setting permissions
 
-To store asset files your application should have WRITE_EXTERNAL_STORAGE 
-permission. To record audio you need RECORD_AUDIO permission. Please note that 
-since Android 6.0, RECORD_AUDIO is not automatically enabled, it must be 
-confirmed in application settings manually.
+In order to store asset files your application must have *WRITE_EXTERNAL_STORAGE*
+permission. To record audio you need *RECORD_AUDIO* permission. Please note that
+since Android 6.0, *RECORD_AUDIO* is not automatically enabled, but must be
+confirmed in the application settings manually.
 
 ```
 <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
@@ -90,30 +89,33 @@ confirmed in application settings manually.
 ### Including resource files
 
 The standard way to ship resource files with your application in Android
-is to  put them in `assets/` directory of your project. But in order to
-make them  available for pocketsphinx files should have physical path,
-as long as they are  within .apk they don't have one. Assets class from
-pocketsphinx-android  provides a method to automatically copy asset
-files to external storage of the  target device.
-`edu.cmu.pocketsphinx.Assets#syncAssets` synchronizes  resources reading
-items from `assets.lst` file located on the top  `assets/`. Before
-copying it matches MD5 checksums of an asset and a file on  external
-storage with the same name if such exists. It only does actualy  copying
-if there is incomplete information (no file on external storage, no any 
-of two .md5 files)  or there is hash mismatch. PocketSphinxAndroidDemo
-contains `ant` script that generates `assets.lst` as well as `.md5`
-files, look  for `assets.xml`. 
+is to put them in the `assets/` directory of your project.
+In order to make them available for pocketsphinx, these files should have
+physical path. However, as long as they are in *.apk* they don't have such a
+physical path.
 
-Please note that if ant build script doesn't run properly in your build 
-process, assets might be out of sync. Make sure that script runs or
-create md5 files and assets.lst yourself.
+The `Assets` class from pocketsphinx-android provides a method to automatically
+copy asset files to the external storage of the  target device.
+`edu.cmu.pocketsphinx.Assets#syncAssets` synchronizes  resources by reading
+items from the `assets.lst` file which is located on the top `assets/`.
+Before copying it matches the MD5 checksums of an asset and a file on external
+storage with the same name in case it exists.
 
-To integrate assets sync in your application do the following
+It only copies the files if there is incomplete information (no file on the
+external storage, .md5 files are not available) or if there is a hash mismatch.
+The PocketSphinxAndroidDemo contains an `ant` script that generates `assets.lst`
+as well as the `.md5` files, look  for `assets.xml`.
 
-  1. Copy `models/assets.xml` build file from demo application into your 
-application into same folder `app`.
-  1. Edit `app/build.gradle` build file to run `assets.xml`, just as in 
-android demo:
+Please note that the assets might be out of sync if the `ant` build script
+didn't run properly in your build process. So, you should make sure that the
+script runs or to create the md5 files and `assets.lst` yourself.
+
+To integrate the assets sync into your application do the following:
+
+1. Copy the `models/assets.xml` build file from the demo application into your
+   application into the same folder `app`.
+2. Edit the `app/build.gradle` build file to run `assets.xml`, just as in the
+   Android demo:
 
 ```
 ant.importBuild 'assets.xml'
@@ -121,43 +123,43 @@ preBuild.dependsOn(list, checksum)
 clean.dependsOn(clean_assets)
 ```
 
-That should do the trick. You can verify that `assets.lst` file was created and md5 files are updated.
+That should do the trick. You can now verify that the `assets.lst` file was
+created and that the md5 files are updated.
 
 ### Sample application
 
-The classes and methods of pocketsphinx-android were designed to resemble the 
-same workflow used in pocketsphinx, except that basic data structures organized 
-into classes and functions working with them are turned into methods of the 
-corresponding classes. So if you are familiar with pocketsphinx you should feel 
-comfortable with pocketsphinx-android too.
+The classes and methods of pocketsphinx-android were designed to resemble the
+same workflow used in pocketsphinx, except that basic data structures are
+turned into classes and functions that work with these structures are turned
+into methods of the corresponding classes. So, if you are familiar with
+pocketsphinx you should feel comfortable with pocketsphinx-android, too.
 
-`SpeechRecognizer` is the main class to access decoder functionality. It
-is  created with the help of `SpeechRecognizerSetup` builder. 
-`SpeechRecognizerBuilder` allows to configure main properties as well as 
-other parameters of teh decoder. The parameters keys and values are the
-same as  those are passed in command-line to pocketsphinx binaries. Read
-[more](/wiki/pocketsphinxhandhelds) about tweaking pocketsphinx
-performance.
+The `SpeechRecognizer` is the main class to access decoder functionality. It
+is created with the help of a `SpeechRecognizerSetup` builder.
+A `SpeechRecognizerBuilder` allows to configure the main properties as well as
+other parameters of the decoder. The parameters’s keys and values are the
+same as those that are passed to the pocketsphinx binaries on the command-line.
+Read more about tweaking the performance of pocketsphinx
+[here](/wiki/pocketsphinxhandhelds).
 
 ```java
 recognizer = defaultSetup()
 	    .setAcousticModel(new File(assetsDir, "en-us-ptm"))
-	    .setDictionary(new File(assetsDir, 
-"cmudict-en-us.dict"))
+	    .setDictionary(new File(assetsDir, "cmudict-en-us.dict"))
 	    .getRecognizer();
 recognizer.addListener(this);
 ```
 
-Decoder configuration is lengthy process that contains IO operation, so it's 
-recommended to run in inside async task.
+The decoder configuration is a lengthy process that contains IO operations, so
+it’s recommended to run it inside an async task.
 
-Decoder supports multiple named searches which you can switch in runtime
+A decoder supports multiple named searches which you can switch in runtime:
 
 ```java
-// Create keyword-activation search.
+// Create keyword-activation search
 recognizer.addKeyphraseSearch(KWS_SEARCH, KEYPHRASE);
 
-// Create grammar-based searches.
+// Create grammar-based searches
 File menuGrammar = new File(assetsDir, "menu.gram");
 recognizer.addGrammarSearch(MENU_SEARCH, menuGrammar);
 
@@ -165,80 +167,86 @@ recognizer.addGrammarSearch(MENU_SEARCH, menuGrammar);
 File digitsGrammar = new File(assetsDir, "digits.gram");
 recognizer.addGrammarSearch(DIGITS_SEARCH, digitsGrammar);
 
-// Create language model search.
+// Create language model search
 File languageModel = new File(assetsDir, "weather.dmp");
 recognizer.addNgramSearch(FORECAST_SEARCH, languageModel);
 ```
 
-Once you setup the decoder and add all the searches you can start recognition 
-with
+Once you set up the decoder and added all the searches you can start recognition
+with:
 
 ```java
 recognizer.startListening(searchName);
 ```
 
-You will get notified on speech end event in `onEndOfSpeech` callback of
-the  recognizer listener. Then you could call `recognizer.stop` or
-`recognizer.cancel()`. Latter will cancel the  recognition, former will
-cause the final result be passed you in `onResult` callback.
+You will get notified on the speech end event in the `onEndOfSpeech` callback of
+the recognizer listener. Then you could call `recognizer.stop()` or
+`recognizer.cancel()`. Latter will cancel the recognition, former will cause the
+final result to be passed in the `onResult` callback.
 
-During the recognition you will get partial results in `onPartialResult` 
+During the recognition you will receive partial results in the `onPartialResult`
 callback.
 
-You can also access other Pocketsphinx method wrapped with Java classes in 
-swig, check for details Decoder, Hypothesis, Segment and NBest classes.
+You can also access other Pocketsphinx methods that are wrapped in Java classes in
+swig. For details check for the `Decoder`, `Hypothesis`, `Segment` and `NBest`
+classes.
 
 
 ## Building pocketsphinx-android
 
-Pocketsphinx is provided with prebuilt binaries and it's not easy to compile it 
-on various platforms. You shouldn't build it unless you understand what you are 
-doing. Use prebuilt binaries instead.
+Pocketsphinx is provided with prebuilt binaries and it’s challenging to compile
+it on various platforms. Unless you fully understand what you are doing, you
+should rather not build it yourself. We recommend to use prebuilt binaries
+instead.
 
 ### Build dependencies
 
-  *  [Gradle](http://gradle.org/ )
-  *  [JDK](http://openjdk.java.net/ ) **>= 1.6**
-  *  [SWIG](http://www.swig.org/ ) **>= 2.0**
-  *  [Android SDK](http://developer.android.com/sdk/ )
-  *  [Android NDK](http://developer.android.com/tools/sdk/ndk/ )
+  *  [Gradle](http://gradle.org/)
+  *  [JDK](http://openjdk.java.net/) >= 1.6
+  *  [SWIG](http://www.swig.org/) >= 2.0
+  *  [Android SDK](http://developer.android.com/sdk/)
+  *  [Android NDK](http://developer.android.com/tools/sdk/ndk/)
 
 ### Building steps
 
 You need to checkout sphinxbase, pocketsphinx and pocketsphinx-android
-and put them in the same folder.
+and put them in the same directory.
 
-```	
-Root folder
- \_pocketsphinx
- \_sphinxbase
- \_pocketsphinx-android
+```
+root-directory
+├─ pocketsphinx
+├─ sphinxbase
+└─ pocketsphinx-android
 ```
 
 Older versions might be incompatible with the latest pocketsphinx-android,
-so you need to make sure you are using latest versions. You can use
-the following command to checkout from repository:
+so you need to make sure you are using the latest versions. You can use the
+following commands to checkout the repositories:
 
+```bash
+git clone https://github.com/cmupshinx/sphinxbase
+git clone https://github.com/cmupshinx/pocketsphinx
+git clone https://github.com/cmupshinx/pocketsphinx-android
 ```
-git clone http://github.com/cmupshinx/sphinxbase
-git clone http://github.com/cmupshinx/pocketsphinx
-git clone http://github.com/cmupshinx/pocketsphinx-android
-```
 
-After arragement of the files you need to update the file
-`local.properties` in the project root and define the following
-properties:
+After arranging the directories you need to update the file `local.properties`
+in the project root and define the following properties:
 
-  * `sdk.dir` - path to Android SDK
-  * `ndk.dir` - path to Android NDK
+  * `sdk.dir` – the path to the Android SDK
+  * `ndk.dir` – the path to the Android NDK
 
 For example:
 
-```
+```bash
 sdk.dir=/home/user/local/adt-bundle-linux-x86_64-20140321/sdk
 ndk.dir=/home/user/local/android-ndk-r9d
 ```
 
-After everything is set, run `gradle build`. It will create 
-`pocketsphinx-android-5prealpha-debug.aar` and 
+After everything is set, run `gradle build`. This will create
+`pocketsphinx-android-5prealpha-debug.aar` and
 `pocketsphinx-android-5prealpha-release.aar` in `build/outputs/aar`.
+
+<span class="post-bottom-nav">
+  [Building an application with pocketsphinx](/wiki/tutorialpocketsphinx)
+  [Building a dictionary](/wiki/tutorialdict)
+</span>

--- a/wiki/tutorialbeforestart.md
+++ b/wiki/tutorialbeforestart.md
@@ -1,177 +1,184 @@
 ---
-layout: page 
+layout: page
 title: Before you start
 ---
-# Before you start
 
-Before you start the development of the speech application, you need to
-consider several important points. They will define the way you'll
-implement the application.
+---
 
-##  Algorithms
+* auto-gen TOC:
+{:toc}
 
-Speech technology puts several important limits on the way it's possible
-to implement the application. For example, as noted above it is
+---
 
-**impossible** to recognize any known word of the language. You need
-to consider the ways to overcome such limitations. Such ways are known 
-for most types of applications out there and described later in
+Before you start developing a speech application, you need to
+consider several important points. They will define the way you will
+implement your application.
+
+## Algorithms
+
+Speech technology sets several important limits to the way you implement an
+application. For example, as noted before, it is *impossible* to recognize *any*
+known word of the language.
+You need to consider ways to overcome such limitations. Such ways are known
+for most types of applications out there and will be described later in the
 tutorial. To follow them, you sometimes need to rethink how your
 application will behave and interact with the user.
 
-Although we try to provide important examples, we obviously can't cover
+Although we try to provide important examples, we obviously can’t cover
 everything. There is no utterance verification or speaker identification
-example yet, though they could be created later. Most algorithms are widely 
-covered in scientific literature, and some of them are explained in tutorial 
-later in the section. Moreover, new methods to solve old problems raise each 
-year.
+example yet, though they could be created later. Most algorithms are widely
+covered in scientific literature and some of them are explained later in the
+tutorial. Moreover, new methods to solve old problems raise each year.
 
-To name several common applications and the way to approach them:
+Let’s go through a list of several common applications and how to approach them:
 
-**Generic dictation** is never so generic. You need to find out a domain
-you'll recognize which can be dialogs, readings, meetings, voicemails,
-legal or medical  transcriptions. If you consider voicemails, note that
-the language there is way more restricted than general language. It's
-actually a very small vocabulary with specialized sequence of terms:
+**Generic dictation** is never as generic as its name says. You need to
+determine a domain to recognize which can be e.g. dialogs, readings, meetings,
+voicemails, legal or medical transcriptions. If you consider voicemails, note
+that the language in this domain is way more restricted than general language.
+It’s actually a very small vocabulary with specialized sequences of terms:
 
-  * It's Sandy. Let's meet tomorrow
-  * Hi. That's Joe, I'm going to sell you that car
+  * It’s Sandy. Let’s meet tomorrow
+  * Hi. That’s Joe, I’m going to sell you that car
 
-There will be a lot of names and that's a problem, but you'll never find
-a voicemail about quantum physics and that's a very good thing. The
-recognizer will use the restrictions you provided with the language
-model to improve accuracy of the result.
+There will be a lot of names, which is certainly a problem, but you’ll never
+find a voicemail about quantum physics – and that’s a very good thing. The
+recognizer will use the restrictions you provided with the language model in
+order to improve the accuracy of the result.
 
-You'll have to build a language model for your domain, but that's not as
-complicated as you might think. Don't afraid as well, if you'll cover
+You’ll have to build a language model for your domain, but that’s not as
+complicated as you might think. It doesn’t matter, if you only covered
 the 60k most common words in English; the accuracy will be the same as
-with  120k words. For other languages with rich morphology the situation
-is different, but also solvable with morphology-based subwords. Also,
-you have to build a  post-processing system, adaptation system and
-user-identification system.
+if you considered 120k words. For other languages with rich morphology the
+situation is different, but also solvable with morphology-based subwords. Also,
+you have to build a post-processing system, an adaptation system and
+a user-identification system.
 
 For **recognition on an embedded processor,** there are two ways to
-consider - recognition on the server and recognition on the device. The former is
-more popular now days because it lets you use the power and flexibility of
-the cloud computations.
+consider – recognition on the server and recognition on the device. The former
+is more popular nowadays because it leverages the power and flexibility of
+cloud computing.
 
 **Language learning** will require you to build a framework for tracking
-incorrect pronunciations. That will include generation of incorrect
-pronunciations and scoring them.
+incorrect pronunciations. That will include the generation and scoring of
+incorrect pronunciations.
 
 For **command and control,** it was popular to use a finite state grammar for a
-long time. Unfortunately, we could not recommend that to you now days. It's
-way better to employ a medium vocabulary recognizer with semantic analysis
-framework on the top to improve user experience and let him use more or
-less natural language. In short, don't build command and control, build 
+long time. However, we do not recommend this approach nowadays. It’s
+way better to employ a medium vocabulary recognizer with a semantic analysis
+framework on top to improve the users’ experience and let them use more or
+less natural language. In short, don’t build command and control, build
 intelligent assistants instead.
 
-For **intelligent assistants** you need not just the recognition, but also 
-intent parsing and database knowledge. For more detail on how to implement this 
-you can check [Lucida](https://github.com/claritylab/ ) powered by 
-[OpenEphyra](https://github.com/TScottJ/OpenEphyra). Dialog systems will 
-require user feedback framework as well.
+For **intelligent assistants** you do not only need the recognition, but also
+intent parsing and database knowledge. For more details on how to implement this
+you can check [Lucida](https://github.com/claritylab/ ) powered by
+[OpenEphyra](https://github.com/TScottJ/OpenEphyra). Dialog systems will
+require a framework for user feedback as well.
 
-**Voice search, semantic analysis and translation** will need to be build on
-the top of the lattices generated by engine. You need to take lattices
-with confidence scores and feed them into the upper levels like
+**Voice search, semantic analysis and translation** will need to be built on
+top of the lattices generated by an engine. You need to take lattices
+with confidence scores and feed them into the upper levels like a
 translation engine.
 
 For open vocabulary recognition like **name and places recognition,** you
 will need a subword language model.
 
 **Text alignment,** like captions synchronization, will require you to build
-a specialized language model from reference text to restrict the search.
+a specialized language model from a reference text to restrict the search.
 
-## Existing accuracy figures
+## Existing accuracy results
 
-For most tasks above there are published accuracy results. You can find
-them if you'll identify the task. Those results could be useful
-or not useful in terms of accuracy for your users. You might count
-that you'll jump over the figures, but it's unlikely that it will be done
-quickly.
+For most tasks above there are published accuracy results. You can look into
+them if you identify the task. Those results can or cannot be useful in terms of
+accuracy for your users. I might be that your accuracy results appear to be
+better than the ones from the publications. However, this might be unlikely and
+might not be as easy to achieve as it seems at first.
 
-For example, the broadcast news recognition task is done with 20-25%
-accuracy. If it's not enough for your application, you probably need to
-consider modification of the application. You might add hand-correction
-step or preliminary adaptation step to improve accuracy. If accuracy
-will not be sufficient after that, probably it's better to think if you
-need speech at all. There are other more reliable interfaces you could
-use. 
+Let’s for instance consider a broadcast news recognition system which has an
+accuracy of 20-25%. If this is not enough for your application, you probably
+need to consider modifying the application. You might add a manual correction
+step or a preliminary adaptation step to improve accuracy. If the accuracy
+will not be sufficient afterwards, then it’s probably better to think about
+whether you need speech at all. There are other, more reliable, interfaces you
+could use.
 
-For example, though ASR-based IVR systems are fancy and handy, many
+For instance, though ASR-based IVR systems are fancy and handy, many
 people still prefer communication with DTMF systems or web-based forms
 or just email to contact the company. Remember that you need an
-effective interface, not modest one.
+effective interface, not a modest one.
 
 ## Resources
 
-Next issue you need to consider, is the availability of the speech
+Another problem you need to consider is the availability of speech
 material for training, testing and optimizing the system. You need to
 find out which resources are available to you.
 
 The **testing set** is a critical issue for any speech recognition
 application. The testing set should be representative enough
-acoustically and terms of language. But the test set shouldn't necessary
-be large, you can spend 10 minutes to create a good one. It might be a
-sample recordings you could do yourself.
+acoustically and in terms of the language. On the other hand, the test set
+doesn’t necessarily need be large, you can spend ten minutes to create a good
+one. It might be a couple of recordings you could do yourself.
 
-For training set and models you should check the resources that are
+For the training set and the models you should check the resources that are
 already present. The increasing interest in speech technology makes
-people  contribute by creation of models for their native languages. In
-general, you'll have to collect audio material for specified language.
-Actually it's not so complicated thing to do. Audio books, movies and
-podcasts provide enough recordings to build very good acoustic model
-with little effort.
+people contribute by creating models for their native languages. In
+general, you’ll have to collect audio material for a specified language.
+Actually it’s not that complicated. Audio books, movies and podcasts provide
+enough recordings to build a very good acoustic model with little effort.
 
-To build a phonetic dictionary you can use existing TTS synthesizer
-which nowdays cover a lot of languages. Also you can boostrap dictionary
+To build a phonetic dictionary you can use one of the existing TTS synthesizers
+which nowadays cover a lot of languages. You can also boostrap a dictionary
 by hand and then extend it with machine learning tools.
 
-For language models you'll have to find a lot of texts for your domain.
+For language models you’ll have to find a lot of texts for your domain.
 It might be textbooks, already transcribed recordings or some other
 sources like website contents crawled on the web.
 
 ## Technologies
 
-Third thing to consider is the set of particular technologies you will 
-build on. Although CMUSphinx tries to provide more or less complete 
-program suite for development of speech applications, you'll sometimes
+A third thing to consider is the set of particular technologies you will
+build on. Although CMUSphinx tries to provide a more or less complete
+programming suite for developing speech applications, you’ll sometimes
 need to use other packages/programming languages/tools. You need to find
-out yourself if you are going to continue with Java, C or any of
-scripting languages CMUSphinx supports. The rule to choose between 
-sphinx4 or pocketsphinx is the following:
+out yourself if you need to continue with Java, C or any of the scripting
+languages CMUSphinx supports. A simple rule to choose between sphinx4 and
+pocketsphinx is the following:
 
-  * Need speed or portability -> use pocketsphinx
-  * Need flexibility and managability -> use sphinx4
+  * If you need *speed or portability* ⇢ use pocketsphinx
+  * If you need *flexibility and managability* ⇢ use sphinx4
 
-Although people often ask what is more accurate sphinx4 or pocketsphinx,
-you shouldn't bother with this question at all. Accuracy is **not** the
-argument here. Both sphinx4 and pocketsphinx provide acceptable accuracy
-and even then it depends on many factors, not just the engine. The thing
-is that engine is just a part of the system which should include many
-more components. If we are talking about large vocabulary decoder, there
-must be diarization framework, adaptation framework and postprocessing
-framework. They all need to cooperate somehow. Flexibility of sphinx4
-allows you to build such a system quickly. It's easy to embed sphinx4
-into flash server like red5 to provide web-based recognition, it's easy
+Although people often ask whether sphinx4 or pocketsphinx is more accurate,
+you shouldn’t bother with this question at all. Accuracy is *not* the
+argument here. Both sphinx4 and pocketsphinx provide sufficient accuracy
+and even then it depends on many factors, not just the engine. The point
+is that the engine is just a part of the system which should include many
+more components. If we are talking about a large vocabulary decoder, there
+must be a diarization framework, an adaptation framework and a postprocessing
+framework. They all need to cooperate somehow. The flexibility of sphinx4
+allows you to build such a system quickly. It’s easy to embed sphinx4
+into a flash server like red5 to provide web-based recognition. It’s easy
 to manage many sphinx4 instances doing large-scale decoding on a
 cluster.
 
 On the other side, if your system needs to be efficient and reasonably
-accurate, if you are running on embedded device or you are interested in
-using recognizer with some exotic language like Erlang, pocketsphinx is
-your choice. It's very hard to integrate Java with other languages not
-supported by JVM pocketsphinx is way better here.
+accurate, if you are running on embedded device or if you are interested in
+using a recognizer with some exotic language like Erlang, then pocketsphinx is
+your choice. It’s very hard to integrate Java with other languages that are not
+supported by the JVM – pocketsphinx is way better in this case.
 
-Next example of what you need to consider a development platform choice.
-If you are bound to some, that's an easy question for you. If you can
-choose, we highly recommend you to use GNU/Linux as  a development
-platform. We can help you with Windows or Mac issues but there are no
-guarantees, our main development platform is Linux. For many tasks
-you'll need to run complex scripts using perl of python. On Windows it
-might be problematic.
+Last, you need to choose your development platform.
+If you are bound to a specific one, that’s an easy task for you. If you can
+choose, we highly recommend to use GNU/Linux as your development platform. We
+can help you with Windows or Mac issues but there are no guarantees – our main
+development platform is Linux. For many tasks you’ll need to run complex scripts
+using Perl or Python. On Windows it might be problematic.
 
-Got it? Let's start! Next section will describe the process of creation
-the sample application either with [sphinx4](/wiki/tutorialsphinx4) or 
-[pocketsphinx](/wiki/tutorialpocketsphinx).  Choose the right one.
+Alright, let’s start! The next sections will describe the process of creating
+a sample application with either [sphinx4](/wiki/tutorialsphinx4) or
+[pocketsphinx](/wiki/tutorialpocketsphinx). Choose the one that fits for you.
+
+<span class="post-bottom-nav">
+  [Overview of the CMUSphinx toolkit](/wiki/tutorialoverview)
+  [Building an application with sphinx4](/wiki/tutorialsphinx4)
+</span>

--- a/wiki/tutorialconcepts.md
+++ b/wiki/tutorialconcepts.md
@@ -1,221 +1,236 @@
 ---
-layout: page 
-title: Basic consepts of speech recognition
+layout: page
+title: Basic concepts of speech recognition
 ---
-# Basic concepts of speech
 
-Speech is a complex phenomenon. People rarely understand how is it produced and 
-perceived. The naive perception is often that speech is built with words, and 
-each word consists of phones. The reality is unfortunately very different. 
-Speech is a dynamic process without clearly distinguished parts. It's always 
-useful to get a sound editor and look into the recording of the speech and 
+---
+
+* auto-gen TOC:
+{:toc}
+
+---
+
+Speech is a complex phenomenon. People rarely understand how is it produced and
+perceived. The naive perception is often that speech is built with words and
+each word consists of phones. The reality is unfortunately very different.
+Speech is a dynamic process without clearly distinguished parts. It's always
+useful to get a sound editor and look into the recording of the speech and
 listen to it. Here is for example the speech recording in an audio editor.
 
 ![waveform](/data/waveform.png)
 
-All modern descriptions of speech are to some degree probabilistic. That means 
-that there are no certain boundaries between units, or between words. Speech to 
-text translation and other applications of speech are never 100% correct. That 
-idea is rather unusual for software developers, who usually work with 
-deterministic systems. And it creates a lot of issues specific only to speech 
+All modern descriptions of speech are to some degree probabilistic. That means
+that there are no certain boundaries between units, or between words. Speech to
+text translation and other applications of speech are never 100% correct. That
+idea is rather unusual for software developers, who usually work with
+deterministic systems. And it creates a lot of issues specific only to speech
 technology.
 
 ## Structure of speech
 
 In current practice, speech structure is understood as follows:
 
-Speech is a continuous audio stream where rather stable states mix with 
-dynamically changed states. In this sequence of states, one can define more or 
-less similar classes of sounds, or **phones**. Words are understood to be built 
-of phones, but this is certainly not true. The acoustic properties of a 
-waveform corresponding to a phone can vary greatly depending on many factors - 
-phone context, speaker, style of speech and so on. The so called coarticulation 
-makes phones sound very different from their "canonical" representation. Next, 
-since transitions between words are more informative than stable regions, 
-developers often talk about **diphones** - parts of phones between two 
-consecutive phones. Sometimes developers talk about subphonetic units - 
-different substates of a phone. Often three or more regions of a different 
-nature can easily be found.
+Speech is a continuous audio stream where rather stable states mix with
+dynamically changed states. In this sequence of states, one can define more or
+less similar classes of sounds, or **phones**. Words are understood to be built
+of phones, but this is certainly not true. The acoustic properties of a
+waveform corresponding to a phone can vary greatly depending on many factors -
+phone context, speaker, style of speech and so on. The so-called coarticulation
+makes phones sound very different from their "canonical" representation. Next,
+since transitions between words are more informative than stable regions,
+developers often talk about **diphones** - parts of phones between two
+consecutive phones. Sometimes developers talk about subphonetic units -
+different substates of a phone. Often three or more regions of a different
+nature can be found.
 
-The number three is easily explained. The first part of the phone depends on 
-its preceding phone, the middle part is stable, and the next part depends on 
-the subsequent phone. That's why there are often three states in a phone 
+The number three can easily be explained: The first part of the phone depends on
+its preceding phone, the middle part is stable and the next part depends on
+the subsequent phone. That's why there are often three states in a phone
 selected for speech recognition.
 
-Sometimes phones are considered in context. Such phones in context are called 
-**triphones** or even **quinphones**. For example "u with left phone b and 
-right phone d" in the word "bad".  And it sounds a bit different from the same 
-phone "u" with left phone b and right phone n" in word "ban". Please note that 
-unlike diphones, they are matched with the same range in waveform as just 
-phones. They just differ by name because they describe slightly different 
-sounds. 
+Sometimes phones are considered in context. Such phones in context are called
+**triphones** or even **quinphones**. For example "u" with left phone "b" and
+right phone "d" in the word "bad" sounds a bit different than the same
+phone "u" with left phone "b" and right phone "n" in word "ban". Please note that
+unlike diphones, they are matched with the same range in waveform as just
+phones. They just differ by name because they describe slightly different
+sounds.
 
-For computational purpose it is helpful to detect parts of triphones instead of 
-triphones as a whole, for example, to create a detector for a beginning of 
-triphone and share it across many triphones. The whole variety of sound 
-detectors can be represented by a small amount of distinct short sound 
-detectors. Usually we use 4000 distinct short sound detectors to compose 
-detectors for triphones. We call those detectors **senones**. A senone's 
-dependence on context could be more complex than just left and right context. 
-It can be a rather complex function defined by a decision tree, or in some 
-other way.
+For computational purpose it is helpful to detect parts of triphones instead of
+triphones as a whole, for example if you want to create a detector for the
+beginning of a triphone and share it across many triphones. The whole variety of
+sound detectors can be represented by a small amount of distinct short sound
+detectors. Usually we use 4000 distinct short sound detectors to compose
+detectors for triphones. We call those detectors **senones**. A senone's
+dependence on context can be more complex than just the left and right context.
+It can be a rather complex function defined by a decision tree, or in some
+other ways.
 
-Next, phones build subword units, like syllables. Sometimes, syllables are 
-defined as "reduction-stable entities". To illustrate, when speech becomes 
-fast, phones often change, but syllables remain the same. Also, syllables are 
-related to intonational contour. There are other ways to build subwords - 
-morphologically-based in morphology-rich languages or phonetically-based. 
+Next, phones build subword units, like syllables. Sometimes, syllables are
+defined as "reduction-stable entities". For instance, when speech becomes
+fast, phones often change, but syllables remain the same. Also, syllables are
+related to an intonational contour. There are other ways to build subwords -
+morphologically-based (in morphology-rich languages) or phonetically-based.
 Subwords are often used in open vocabulary speech recognition.
 
-Subwords form words. Words are important in speech recognition because they 
-restrict combinations of phones significantly. If there are 40 phones and an 
-average word has 7 phones, there must be 40^7 words. Luckily, even a very 
-educated person rarely uses more then 20k words in his practice, which makes 
+Subwords form words. Words are important in speech recognition because they
+restrict combinations of phones significantly. If there are 40 phones and an
+average word has 7 phones, there must be 40^7 words. Luckily, even people with a
+rich vocabulary rarely use more then 20k words in practice, which makes
 recognition way more feasible.
 
-Words and other non-linguistic sounds, which we call **fillers** (breath, um, 
-uh, cough), form **utterances**. They are separate chunks of audio between 
+Words and other non-linguistic sounds, which we call **fillers** (breath, um,
+uh, cough), form **utterances**. They are separate chunks of audio between
 pauses. They don't necessary match sentences, which are more semantic concepts.
 
-On the top of this, there are dialog acts like turns, but they go beyond the 
-purpose of the document.
+On the top of this, there are dialog acts like turns, but they go beyond the
+purpose of this document.
 
 ## Recognition process
 
-The common way to recognize speech is the following: we take waveform, split it 
-on utterances by silences then try to recognize what's being said in each 
-utterance. To do that we want to take all possible combinations of words and 
-try to match them with the audio. We choose the best matching combination. 
-There are few important things in this
-match.
+The common way to recognize speech is the following: we take a waveform, split it
+at utterances by silences and then try to recognize what's being said in each
+utterance. To do that, we want to take all possible combinations of words and
+try to match them with the audio. We choose the best matching combination.
 
-First of all it's a concept of **features**. Since number of parameters is 
-large, we are trying to optimize it. Numbers that are calculated from speech 
-usually by dividing speech on frames. Then for each frame of length typically 
-10 milliseconds we extract 39 numbers that represent the speech. That's called 
-**feature vector**. The way to generate numbers is a subject of active 
-investigation, but in simple case it's a derivative from spectrum.
+There are some important concepts in this matching process.
+First of all it's the concept of **features**. Since the number of parameters is
+large, we are trying to optimize it. Numbers that are calculated from speech
+usually by dividing the speech into frames. Then for each frame, typically of
+10 milliseconds length, we extract 39 numbers that represent the speech.
+That's called a **feature vector**. The way to generate the number of parameters
+is a subject of active investigation, but in a simple case it's a derivative
+from the spectrum.
 
-Second it's a concept of the **model**. Model describes some mathematical 
-object that gathers common attributes of the spoken word. In practice, for 
-audio model of senone is gaussian mixture of it's three states - to put it 
-simple, it's a most probable feature vector. From concept of the model the 
-following issues raised - how good does model fits practice, can model  be made 
-better of it's internal model problems, how adaptive model is to the changed 
-conditions.
+Second, it's the concept of the **model**. A model describes some mathematical
+object that gathers common attributes of the spoken word. In practice, for an
+audio model of senone it is the gaussian mixture of it's three states - to put
+it simple, it's the most probable feature vector. From the concept of the model
+the following issues raise:
 
-The model of speech is called [Hidden Markov 
-Model](http://en.wikipedia.org/wiki/Hidden_Markov_model) or HMM, it's a generic 
-model that describes black-box communication channel. In this model process is 
-described as a sequence of states which change each other with certain 
-probability. This model is intended to describe any sequential process like 
-speech. It has been proven to be really practical for speech decoding.
+* how well does the model describe reality,
+* can the model be made better of it's internal model problems and
+* how adaptive is the model if conditions change
 
-Third, it's a matching process itself. Since it would take a huge time more 
-than universe existed to compare all feature vectors with all models, the 
-search is often optimized by many tricks. At any points we maintain best 
-matching variants and extend them as time goes producing best matching variants 
-for the next frame.
+The model of speech is called [Hidden Markov
+Model](http://en.wikipedia.org/wiki/Hidden_Markov_model) or HMM. It's a generic
+model that describes a black-box communication channel. In this model process is
+described as a sequence of states which change each other with a certain
+probability. This model is intended to describe any sequential process like
+speech. HMMs have been proven to be really practical for speech decoding.
+
+Third, it's a matching process itself. Since it would take longer
+than universe existed to compare all feature vectors with all models, the
+search is often optimized by applying many tricks. At any points we maintain the
+best matching variants and extend them as time goes on, producing the best
+matching variants for the next frame.
 
 ## Models
 
-According to the speech structure, three models are used in speech recognition 
+According to the speech structure, three models are used in speech recognition
 to do the match:
 
-An **acoustic model** contains acoustic properties for each senone. There are 
-context-independent models that contain properties (most probable feature 
-vectors for each phone) and context-dependent ones (built from senones with 
+An **acoustic model** contains acoustic properties for each senone. There are
+context-independent models that contain properties (the most probable feature
+vectors for each phone) and context-dependent ones (built from senones with
 context).
 
-A **phonetic dictionary** contains a mapping from words to phones. This mapping 
-is not very effective. For example, only two to three pronunciation variants 
-are noted in it, but it's practical enough most of the time. The dictionary is 
-not the only variant of mapper from words to phones. It could be done with some 
+A **phonetic dictionary** contains a mapping from words to phones. This mapping
+is not very effective. For example, only two to three pronunciation variants
+are noted in it. However, it's practical enough most of the time. The dictionary
+is not the only method for mapping words to phones. You could also use some
 complex function learned with a machine learning algorithm.
 
-A **language model** is used to restrict word search. It defines which word 
-could follow previously recognized words (remember that matching is a 
-sequential process) and helps to significantly restrict the matching process by 
-stripping words that are not probable. Most common language models used are 
-n-gram language models-these contain statistics of word sequences-and finite 
-state language models-these define speech sequences by finite state automation, 
-sometimes with weights. To reach a good accuracy rate, your language model must 
-be very successful in search space restriction. This means it should be very 
+A **language model** is used to restrict word search. It defines which word
+could follow previously recognized words (remember that matching is a
+sequential process) and helps to significantly restrict the matching process by
+stripping words that are not probable. The most common language models are
+n-gram language models–these contain statistics of word sequences–and finite
+state language models–these define speech sequences by finite state automation,
+sometimes with weights. To reach a good accuracy rate, your language model must
+be very successful in search space restriction. This means it should be very
 good at predicting the next word. A language model usually
-restricts the vocabulary considered to the words it contains. That's an issue 
-for name recognition. To deal with this, a language model can contain smaller 
-chunks like subwords or even phones. Please note that search space restriction 
-in this case is usually worse and corresponding recognition accuracies are 
-lower than with a word-based language model.
+restricts the vocabulary that is considered to the words it contains.
+That's an issue for name recognition. To deal with this, a language model can
+contain smaller chunks like subwords or even phones. Please note that the search
+space restriction in this case is usually worse and the corresponding recognition
+accuracies are lower than with a word-based language model.
 
-Those three entities are combined together in an engine to recognize speech. If 
-you are going to apply your engine for some other language, you need to get 
-such structures in place. For many languages there are acoustic models, 
-phonetic dictionaries and even large vocabulary language models available for 
+Those three entities are combined together in an engine to recognize speech. If
+you are going to apply your engine for some other language, you need to get
+such structures in place. For many languages there are acoustic models,
+phonetic dictionaries and even large vocabulary language models available for
 download.
 
-## Other concepts used
+## Other used concepts
 
-A **Lattice** is a directed graph that represents variants of the recognition. 
-Often, getting the best match is not practical; in that case, lattices are good 
-intermediate formats to represent the recognition result. 
+A **Lattice** is a directed graph that represents variants of the recognition.
+Often, getting the best match is not practical. In that case, lattices are good
+intermediate formats to represent the recognition result.
 
-**N-best lists** of variants are like lattices, though their representations 
+**N-best lists** of variants are like lattices, though their representations
 are not as dense as the lattice ones.
 
-**Word confusion networks** (sausages) are lattices where the strict order of 
+**Word confusion networks** (sausages) are lattices where the strict order of
 nodes is taken from lattice edges.
 
-**Speech database** - a set of typical recordings from the task database. If we 
-develop dialog system it might be dialogs recorded from users. For  dictation 
-system it might be reading recordings. Speech databases are used to train, tune 
+**Speech database** - a set of typical recordings from the task database. If we
+develop dialog system it might be dialogs recorded from users. For dictation
+system it might be reading recordings. Speech databases are used to train, tune
 and test the decoding systems.
 
-**Text databases** - sample texts collected for language model training and so 
-on. Usually, databases of texts are collected in sample text form. The issue 
-with collection is to put present documents (PDFs, web pages, scans) into 
-spoken text form. That is, you need to remove tags and headings, to expand 
-numbers to their spoken form, and to expand abbreviations.
+**Text databases** - sample texts collected for e.g. language model training.
+Usually, databases of texts are collected in sample text form. The issue
+with such a collection is to put present documents (like PDFs, web pages, scans)
+into a spoken text form. That is, you need to remove tags and headings, to expand
+numbers to their spoken form and to expand abbreviations.
 
 ## What is optimized
 
-When speech recognition is being developed, the most complex issue is to make 
-search precise (consider as many variants to match as possible) and to make it 
-fast enough to not run for ages. There are also issues with making the model 
-match the speech since models aren't perfect.
+When speech recognition is being developed, the most complex problem is to make
+search precise (consider as many variants to match as possible) and to make it
+fast enough to not run for ages. Since models aren't perfect, another challenge
+is to make the model match the speech.
 
-Usually the system is tested on a test database that is meant to represent the 
+Usually the system is tested on a test database that is meant to represent the
 target task correctly.
 
 The following characteristics are used:
 
-**Word error rate.** Let we have original text and recognition text of length 
-of *N* words. From them the *I* words were inserted *D* words were deleted and 
-*S* words were substituted Word error rate is
+**Word error rate.** Let’s assume we have an original text and a recognition
+text with a length of *N* words. *I* is the number of inserted words,
+*D* is the number of deleted words and *S* represent the number of substituted
+words. With this, the word error rate can be calculated as
 
 WER = (I + D + S) / N
 
-WER is usually measured in percent.
+The WER is usually measured in percent.
 
-**Accuracy.** It is almost the same thing as word error rate, but it doesn't 
-count insertions. 
+**Accuracy.** It is almost the same as the word error rate, but it doesn't
+take insertions into account.
 
 Accuracy = (N - D - S) / N
 
-Accuracy is actually a worse measure for most tasks, since insertions are also 
-important in final results. But for some tasks, accuracy is a reasonable 
-measure of the decoder performance.
+For most tasks, the accuracy is a worse measure than the WER, since insertions
+are also important in the final results. However, for some tasks, the accuracy
+is a reasonable measure of the decoder performance.
 
-**Speed.** Suppose the audio file was 2 hours and the decoding took 6 hours. 
-Then speed is counted as 3xRT.
+**Speed.** Suppose an audio file has a recording time (RT) of 2 hours and the
+decoding took 6 hours. Then the speed is counted as 3xRT.
 
-**ROC curves.** When we talk about detection tasks, there are false alarms and 
-hits/misses; ROC curves are used. A curve is a graphic that describes the 
-number of false alarms vs number of hits, and tries to find optimal point where 
-the number of false alarms is small and number of hits matches 100%.
+**ROC curves.** When we talk about detection tasks, there are false alarms and
+hits/misses. To illustrate these, [ROC](https://en.wikipedia.org/wiki/Receiver_operating_characteristic) curves
+are used. Such a curve is a diagram that describes the number of false alarms
+versus the number of hits. It tries to find the optimal point where the number
+of false alarms is small and the number of hits matches 100%.
 
-There are other properties that aren't often taken into account, but still 
-important for many practical applications. Your first task should be to build 
-such a measure and systematically apply it during the system development. Your 
-second task is to collect the test database and test how does your application 
-perform.
+There are other properties that aren’t often taken into account, but still
+important for many practical applications. Your first task should be to build
+such a measure and systematically apply it during the system development. Your
+second task is to collect the test database and test how your application
+performs.
+
+<span class="post-bottom-nav">
+  [Tutorial Introduction](/wiki/tutorial)
+  [Overview of the CMUSphinx toolkit](/wiki/tutorialoverview)
+</span>

--- a/wiki/tutorialdict.md
+++ b/wiki/tutorialdict.md
@@ -1,121 +1,129 @@
 ---
-layout: page 
-title: Building phonetic dictionary
+layout: page
+title: Building a phonetic dictionary
 ---
-# Building phonetic dictionary
+
+---
+* auto-gen TOC:
+{:toc}
+---
 
 ### Introduction
 
-Phonetic dictionary provides system the data to map vocabulary words to 
-sequence of phonemes. It looks like this:
+A phonetic dictionary provides the system with a mapping of vocabulary words
+to sequences of phonemes. It might look like this:
 
-	
 	hello H EH L OW
 	world W ER L D
 
+A dictionary can also contain alternative pronunciations. In that case you can
+designate them with a number in parentheses:
 
-Dictionary can contain alternative pronunciations, in that case you can 
-designate them with a number in parenthesis
-
-	
 	the TH IH
 	the(2) TH AH
 
+There are various phonesets to represent phones, such as
+[IPA](https://en.wikipedia.org/wiki/International_Phonetic_Alphabet) or
+[SAMPA](https://en.wikipedia.org/wiki/Speech_Assessment_Methods_Phonetic_Alphabet).
+CMUSphinx does not yet require you to use any well-known phoneset, moreover, it
+prefers to use letter-only phone names without special symbols. This requirement
+simplifies some processing algorithms, for example, you can create files with
+phone names as part of the filenames without any violating of the OS filename
+requirements.
 
-There are various phonesets to represent phones like IPA or SAMPA, CMUSphinx 
-does not yet require you to use any well-known phoneset, moreover, it prefers 
-to use letter-only phone names without special symbols. This requirement 
-simplifies some processing algorithms, for example, you can create files with 
-phone names as part of the filenames without violation of the OS filename requirements.
+A dictionary should contain all the words you are interested in, otherwise
+the recognizer will not be able to recognize them. However, it is not sufficient
+to have the words in the dictionary. The recognizer looks for a word in both
+the dictionary and the language model. Without the language model, a word will
+not be recognized, even if it is present in the dictionary.
 
-Dictionary should contain all the words you are interested in, otherwise 
-recognizer will not be able to recognize them. However, it is not sufficient to 
-have the words in the dictionary, the recognizer looks for the word both in the 
-dictionary and in the language model. Without language model the word will not 
-be recognized even if you added it in the dictionary.
-
-There is no need to remove unused words from the dictionary unless you want to 
+There is no need to remove unused words from the dictionary unless you want to
 save memory, extra words in the dictionary do not affect accuracy.
+
 
 ### Using existing dictionaries
 
-There are number of dictionaries which cover languages we support - CMUDict for 
-US English, French, German, Russian, Dutch, Italian, Spanish, Mandarin. Other 
-dictionaries might be found on the web. If dictionary has proper format you can 
-use it.
+There are a number of dictionaries which cover languages we support – [CMUDict](https://github.com/cmusphinx/cmudict)
+for US English, French, German, Russian, Dutch, Italian, Spanish and Mandarin.
+Other dictionaries might be found on the web. If a dictionary has a proper
+format you can use it.
 
-If dictionary does not cover all the words you are interested in you can extend 
-it with g2p tool.
+If a dictionary does not cover all the words you are interested in, you can
+extend it with the *g2p* tool.
 
 
-### Using G2P-seq2seq to extend the dictionary
+### Using g2p-seq2seq to extend the dictionary
 
-There are various tools to help you to extend an existing dictionary for new 
-words or to build a new dictionary from scratch: 
-[Phonetisaurus](http://code.google.com/p/phonetisaurus), 
-[Sequitur](http://www-i6.informatik.rwth-aachen.de/web/Software/g2p.html). 
+There are various tools to help you to extend an existing dictionary for new
+words or to build a new dictionary from scratch. Two of them are
+[Phonetisaurus](http://code.google.com/p/phonetisaurus) and
+[Sequitur](http://www-i6.informatik.rwth-aachen.de/web/Software/g2p.html).
 
-We recommend to use our latest tool [g2p-seq2seq 
-](https://github.com/cmusphinx/g2p-seq2seq). It is based on neural networks 
-implemented in Tensorflow framework and provides a state of the art accuracy of 
-conversion.
+We recommend to use our latest tool [g2p-seq2seq
+](https://github.com/cmusphinx/g2p-seq2seq). It is based on neural networks
+implemented in the Tensorflow framework and provides a state-of-the-art accuracy
+of conversion.
 
-An English model 2-layer LSTM with 512 hidden units is [available for 
-download](https://sourceforge.net/projects/cmusphinx/files/G2P%20Models/g2p-seq2seq-cmudict.tar.gz/download) on cmusphinx website. Unpack the model after download. It 
-is trained on CMU English dictionary. Read my lips - this model works only for 
-English. For other languages you need to bootstrap dictionary first as 
-described below and then use G2P tool to extend it.
+An English model 2-layer LSTM with 512 hidden units is [available for
+download](https://sourceforge.net/projects/cmusphinx/files/G2P%20Models/g2p-seq2seq-cmudict.tar.gz/download) on the CMUSphinx website. Unpack the model after downloading. It
+is trained on the CMU English dictionary. As the name says, this model works
+only for English. For other languages you first need to bootstrap a dictionary
+as described below and then use the G2P tool to extend it.
 
-The easiest way to check how the tool works is to run it the interactive mode 
-with model above and type the words
+The easiest way to check how the G2P tool works is to run the interactive
+mode with the model from above:
 
     g2p-seq2seq --interactive --model model_folder_path
-
 
     > hello
     HH EH L OW
 
-To generate pronunciations for an English word list with a trained model, run
+To generate pronunciations for an English word list with a trained model, run:
 
     g2p-seq2seq --decode your_wordlist --model model_folder_path
 
 The wordlist is a text file with words, one word per line.
 
-To train G2P you need a dictionary (word and phone sequence per line in 
-standard form). To run the training
+To train G2P you need a dictionary (a word and phone sequence per line in
+the standard form). Run the training with:
 
     g2p-seq2seq --train train_dictionary.dic --model model_folder_path
 
-For more information on the tool see the corresponding page.
+For more information on the G2P tool have a look at the [Readme of the G2P project](https://github.com/cmusphinx/g2p-seq2seq).
 
-### Bootstrapping dictionary for other languages
+### Bootstrapping a dictionary for other languages
 
-If you do not have dictionary for your language there are usually several ways 
-on how you can obtain them.
+If you do not have a dictionary for your language there are usually several ways
+how you can create them.
 
-Usually dictionaries are bootstrapped with hand-written rules. You can find a 
-list of phonemes for your language in Wikipedia page about your language and 
-write a simple Python script to map words to phonemes. The best dictionary 
-could not be covered with rules though, most languages have quite irregular 
-pronunciation which might not be very obvious for newcomer even if it is 
-conventionally thought you speak what is written. This is due to coarticulation 
-effects in human speech. But for basic dictionary rules are sufficiently good 
-enough.
+Usually, dictionaries are bootstrapped with hand-written rules. You can find a
+list of phonemes for your language in the Wikipedia page about your language and
+write a simple Python script to map words to phonemes. The best dictionary
+could not be covered with rules though, most languages have quite irregular
+pronunciation which might not be very obvious for a newcomer even if it is
+conventionally thought that you speak what is written. This is due to
+coarticulation effects in human speech. However, for a basic dictionary, rules
+are sufficiently good enough.
 
-You can crawl Wiktionary to get mapping for significant amount of words covered 
-there.
+You can crawl the Wiktionary to get a mapping for a significant amount of words
+covered there.
 
-You can use TTS tools like from [OpenMary](http://mary.dfki.de/) written in 
-Java or from [Espeak](http://espeak.sourceforge.net) written in C to create the 
+You can use TTS tools like from [OpenMary](http://mary.dfki.de/) written in
+Java or from [Espeak](http://espeak.sourceforge.net) written in C to create the
 phonetic dictionary for the languages they support.
 
-Many languages which use hieroglyphs like Korean or Japanese have specialized 
-software like [Mecab](https://sourceforge.net/projects/mecab) to romanize their 
-words. You can use Mecab to build a phonetic dictionary by converting words to 
-romanized form and then simply applying rules to turn them into phones.
+Many languages which use hieroglyphs like Korean or Japanese have specialized
+software like [Mecab](https://sourceforge.net/projects/mecab) to romanize their
+words. You can use Mecab to build a phonetic dictionary by converting words to
+the romanized form and then simply applying rules to turn them into phones.
 
-It is enough to transcribe few thousand most common words to bootstrap the 
+It is enough to transcribe a few thousand most common words to bootstrap the
 dictionary.
 
-Once dictionary is bootstrapped you can extend it to larger vocabulary with the 
-g2p-seq2seq tool as described in previous chapter.
+Once your dictionary is bootstrapped you can extend it to hold a larger
+vocabulary with the g2p-seq2seq tool as described in the previous section.
+
+<span class="post-bottom-nav">
+  [Using PocketSphinx on Android](/wiki/tutorialandroid)
+  [Building a language model](/wiki/tutoriallm)
+</span>

--- a/wiki/tutoriallm.md
+++ b/wiki/tutoriallm.md
@@ -1,30 +1,30 @@
 ---
-layout: page 
-title: Building language model
+layout: page
+title: Building a language model
 ---
 
+---
 * auto-gen TOC:
 {:toc}
+---
 
-# Building Language Model
+The language model is an important component of the configuration which tells
+the decoder which sequences of words are possible to recognize.
 
-Language model is an important component of the configuration which
-tells the decoder which sequence of words are possible to recognize.
-
-There are several types of models - keyword lists, grammars and
-statistical language models, phonetic language models. They have
-different capabilities and performance properties. You can chose any
-decoding mode according to your needs and you can even switch between
-modes in runtime. See [Pocketsphinx
-tutorial](/wiki/tutorialpocketsphinx/#searches) for details.
+There are several types of models: keyword lists, grammars and statistical
+language models and phonetic language models. They have different capabilities
+and performance properties. You can chose any decoding mode according to your
+needs and you can even switch between modes in runtime.
+See [the Pocketsphinx tutorial](/wiki/tutorialpocketsphinx/#searches) for more
+details.
 
 ## Keyword lists
 
-Pocketsphinx supports keyword spotting mode where you can specify the keyword 
-list to look for. The advantage of this mode is that you can specify a 
-threshold for each keyword so that keyword can be detected in continuous 
-speech. All other modes will try to detect the words from grammar even if you 
-used words which are not in grammar. The keyword list looks like this:
+Pocketsphinx supports a keyword spotting mode where you can specify a list of
+keywords to look for. The advantage of this mode is that you can specify a
+threshold for each keyword so that keywords can be detected in continuous
+speech. All other modes will try to detect the words from a grammar even if you
+used words which are not in the grammar. A typical keyword list looks like this:
 
 ```
 oh mighty computer /1e-40/
@@ -32,269 +32,267 @@ hello world /1e-30/
 other phrase /1e-20/
 ```
 
-Threshold must be specified for every keyphrase. For shorter keyphrase
-you can use smaller thresholds like `1e-1`, for longer keyphrase the
+The threshold must be specified for every keyphrase. For shorter keyphrases
+you can use smaller thresholds like `1e-1`, for longer keyphrases the
 threshold must be bigger, up to `1e-50`. If your keyphrase is very
-long, larger than 10 syllables, it is recommended to split it and spot
-for parts separately. Threshold must be tuned to balance between false
-alarms and missed detections, the best way to tune threshold is to use
-a prerecorded audio file. Tuning process is the following:
+long – larger than 10 syllables – it is recommended to split it and spot
+for parts separately. The threshold must be tuned to balance between false
+alarms and missed detections. The best way to do this is to use a prerecorded
+audio file. The common tuning process is the following:
 
- 1. Take a long recording with few occurrences of your keywords and some other 
-sounds. You can take a movie sound or something else. The length of the audio 
-should be approximately 1 hour
- 1. Run keyword spotting on that file with different thresholds for every 
-keyword, use the following command: 
-```
+ 1. Take a long recording with few occurrences of your keywords and some other
+sounds. You can take a movie sound or something else. The length of the audio
+should be approximately 1 hour.
+ 2. Run a keyword spotting on that file with different thresholds for every
+keyword, use the following command:
+```bash
  pocketsphinx_continuous -infile <your_file.wav> -keyphrase <your keyphrase> \
   -kws_threshold <your_threshold> -time yes
 ```
-The command will print many lines, some of them are keywords with detection 
-times and confidences. You can also disable extra logs with `-logfn 
+The command will print many lines, some of them are keywords with detection
+times and confidences. You can also disable extra logs with the `-logfn
 your_file.log` option to avoid clutter.
- 1. From keyword spotting results count how many false alarms and missed 
-detections you've encountered
- 1. Select the threshold with smallest amount of false alarms and missed 
-detections
+ 3. From your keyword spotting results count how many false alarms and missed
+detections you've encountered.
+ 4. Select the threshold with the smallest amount of false alarms and missed
+detections.
 
-For the best accuracy it is better to have keyphrase with 3-4 syllables. Too 
+For the best accuracy it is better to have a keyphrase with 3-4 syllables. Too
 short phrases are easily confused.
 
-Keyword lists are supported by pocketsphinx only, not by sphinx4.
+Keyword lists are only supported by pocketsphinx, sphinx4 cannot handle them.
 
-### Using keyword lists with Pocketsphinx
+### Using keyword lists with PocketSphinx
 
-To use keyword list in command line specify it with `-kws` option. Also
-you can use a `-keyphrase` option to specify a single keyphrase.
+To use keyword list in the command line specify it with the `-kws` option. You
+can also use a `-keyphrase` option to specify a single keyphrase.
 
-In Python you can either specify options in configuration object or add a named 
-search for keyphrase:
+In Python you can either specify options in the configuration object or add a
+named search for a keyphrase:
 
-    decoder.set_kws('keypharse', kws_file)
-    decoder.set_search('keyphrase')
- 
-In Android
+```python
+decoder.set_kws('keypharse', kws_file)
+decoder.set_search('keyphrase')
+```
 
-    recognizer.setKws('keyphrase', kwsFile);
-    recognizer.startListening('keyphrase')
+In Android it looks similar:
 
-Please note that `-kws` conflicts with `-lm` or `-jsgf`. You can not specify 
-both. 
+```java
+recognizer.setKws('keyphrase', kwsFile);
+recognizer.startListening('keyphrase')
+```
+
+Please note that `-kws` conflicts with the `-lm` and `-jsgf` options. You cannot
+specify both.
 
 ## Grammars
 
-Grammars describe a very simple type of the language for command and control.
-They are usually written by hand or generated automatically within the code. 
-Grammars usually do not have probabilities for word sequences, but some 
-elements might be weighed. Grammars can be created with JSGF format and 
-usually have extension like .gram or .jsgf. 
+A grammar describes a very simple type of the language for command and control.
+They are usually written by hand or generated automatically within the code.
+Grammars usually do not have probabilities for word sequences, but some
+elements might be weighed. They can be created with the Java Speech Grammar
+Format ([JSGF](https://en.wikipedia.org/wiki/JSGF)) and usually have a file
+extension like *.gram* or *.jsgf*.
 
 Grammars allow you to specify possible inputs very precisely, for example,
 that a certain word might be repeated only two or three times. However,
 this strictness might be harmful if your user accidentally skips the
-words which the grammar requires. In that case whole recognition will fail.
-For that reason it is better to make grammars more relaxed, instead of
-phrases, list just the bag of words allowing arbitrary order. Avoid very
-complex grammars with many rules and cases, it just slows the
-recognizer, you can use simple rules instead. In the past, grammars
+words which the grammar requires. In that case the whole recognition will fail.
+For that reason it is better to make grammars more flexible. Instead of
+phrases, just list the bag of words allowing arbitrary order. Avoid very
+complex grammars with many rules and cases. It just slows down the
+recognizer and you can use simple rules instead. In the past, grammars
 required a lot of effort to tune them, to assign variants properly and
 so on. The big VXML consulting industry was about that.
 
 ### Building a grammar
 
-Grammars are usually written manually in JSGF format:
+Grammars are usually written manually in the Java Speech Grammar
+Format (JSGF):
 
-```	
+```
 #JSGF V1.0;
 
 grammar hello;
 public <greet> = (good morning | hello) ( bhiksha | evandro | rita | will );
 ```
 
-For more information on JSGF format see the [full documentation on 
-W3C](http://www.w3.org/TR/jsgf/)
+For more information on JSGF see the
+[full documentation on W3C](http://www.w3.org/TR/jsgf/).
 
 ### Using your grammar with PocketSphinx
 
-To use grammar in command line specify it with `-jsgf` option.
+To use your grammar in the command line specify it with the `-jsgf` option.
 
-In Python you can either specify options in configuration object or add a named 
-search for a grammar:
+In Python you can either specify options in the configuration object or add a
+named search for a grammar:
 
-    decoder.set_jsgf('grammar', jsgf_file)
-    decoder.set_search('grammar')
- 
-In Android
+```python
+decoder.set_jsgf('grammar', jsgf_file)
+decoder.set_search('grammar')
+```
 
-    recognizer.setJsgf('grammar', jsgfFile);
-    recognizer.startListening('grammar')
+In Android this looks similiar:
 
-Please note that `-jsgf` conflicts with `-kws` or `-jsgf`. You can not specify 
-both. 
+```java
+recognizer.setJsgf('grammar', jsgfFile);
+recognizer.startListening('grammar')
+```
 
+Please note that `-jsgf` conflicts with the `-kws` and `-jsgf` options. You
+cannot specify both.
 
 ## Language models
 
-Statistical language models describe more complex language. They contain 
-probabilities of the words and word combinations. Those probabilities
-are  estimated from sample data and automatically have some
-flexibility. For example, every combination from the vocabulary is
-possible, though probability of each combination will vary. For
-example if you create statistical language  model from a list of words
-it will still allow to decode word combinations though it might not be
-your intent.
+Statistical language models describe more complex language. They contain
+probabilities of the words and word combinations. Those probabilities are
+estimated from sample data and automatically have some flexibility. Every
+combination from the vocabulary is possible, although the probability of each
+combination will vary. For example, if you create a statistical language model
+from a list of words it will still allow to decode word combinations even though
+this might not have been your intent.
 
 Overall, statistical language models are recommended for free-form input
-where user could say anything in a natural language. They require
+where the user could say anything in a natural language. They require
 way less engineering effort than grammars. You just list the possible
 sentences. For example, you might list numbers like "twenty one" and
-"thirty three" and statistical language model will allow "thirty one"
-with certain probability as well.
+"thirty three" and a statistical language model will allow "thirty one"
+with a certain probability as well.
 
-Overall, modern speech recognition interfaces tend to be more natural and avoid 
-command-and-control style of the previous generation. For that reason most 
-interface designers prefer natural language recognition with a statistical 
-language model than old-fashioned VXML grammars.
+In general, modern speech recognition interfaces tend to be more natural and
+avoid the command-and-control style of the previous generation. For that reason
+most interface designers prefer natural language recognition with a statistical
+language model instead of using old-fashioned VXML grammars.
 
-On the topic of design of the VUI interfaces you might be interested in
-the  following book: [ It's Better to Be a Good Machine Than a Bad
-Person: Speech  Recognition and Other Exotic User Interfaces at the
-Twilight of the Jetsonian  Age by Bruce 
-Balentine](http://www.amazon.com/Better-Good-Machine-Than-Person/dp/1932558098
-)
+On the topic of desiging VUI interfaces you might be interested in
+the following book: [It's Better to Be a Good Machine Than a Bad Person:
+Speech Recognition and Other Exotic User Interfaces at the Twilight of the
+Jetsonian  Age](http://www.amazon.com/Better-Good-Machine-Than-Person/dp/1932558098)
+by Bruce Balentine.
 
-There are many ways to build the statistical language models. When your
-data  set is large, it makes sense to use CMU language modeling toolkit.
-When a model  is small, you can use an online quick web service. When
-you need specific  options or you just want to use your favorite toolkit
-which builds ARPA models,  you can use it.
+There are many ways to build statistical language models. When your
+data set is large, it makes sense to use the CMU language modeling toolkit.
+When a model is small, you can use a quick online web service. When
+you need specific options or you just want to use your favorite toolkit
+which builds ARPA models, you can use this as well.
 
-Language model can be stored and loaded in three different formats - text 
-[ARPA](sphinx4/standardgrammarformats) format, binary BIN format and
-binary DMP format. The ARPA format takes more space but it is possible to
-edit it. ARPA files have `.lm` extension. Binary formats take
-significantly less space and load faster. Binary files have
-`.lm.bin` extension. It is also possible to  convert between formats.
-DMP format is obsolete and not recommended.
+A language model can be stored and loaded in three different formats: *text
+[ARPA](/wiki/arpaformat)* format, *binary BIN* format and *binary DMP* format.
+The ARPA format takes more space but it is possible to edit it. ARPA files have
+an `.lm` extension. Binary formats take significantly less space and load
+faster. Binary files have a `.lm.bin` extension. It is also possible to convert
+between these formats. The DMP format is obsolete and not recommended.
 
-### Building a Statistical Language Model
+### Building a statistical language model
 
 ### Text preparation
 
 First of all you need to prepare a large collection of clean texts.
 Expand  abbreviations, convert numbers to words, clean non-word items.
-For example to  clean Wikipedia XML dumps you can use special python
+For example to clean Wikipedia XML dumps you can use special Python
 scripts like [Wikiextractor](https://github.com/attardi/wikiextractor).
-To clean HTML pages you can try 
-[BoilerPipe](http://code.google.com/p/boilerpipe).  It's a nice package
-specifically created to  extract text from HTML.
+To clean HTML pages you can try
+[BoilerPipe](http://code.google.com/p/boilerpipe). It’s a nice package
+specifically created to extract text from HTML.
 
 For an example on how to create a language model from Wikipedia text, please
 see this [blog
 post](http://trulymadlywordly.blogspot.ru/2011/03/creating-text-corpus-from-wiki
-pedia.html).
+pedia.html). Movie subtitles are also a good source for spoken language.
 
-Once you have gone through the language model process, please submit your langauge 
-model to CMUSphinx project.  We'd be glad to share it!
+Once you have gone through the language modeling process, please submit your
+language model to the CMUSphinx project. We'll be happy to share it!
 
-Movie subtitles are a good source for spoken language.
+Language modeling for Mandarin and other similar languages, is largely the
+same as for English, with one additional consideration. The difference is that
+the input text must be word segmented. A segmentation tool and an associated
+word list is provided to accomplish this.
 
-Language modeling for many languages like Mandarin is largely the same
-as in  English, with one addditional consideration, which is that the
-input text must  be word segmented. A segmentation tool and associated
-word list is provided to  accomplish this.
+### Training an ARPA model with SRILM
 
-### ARPA model training with SRILM
+Training a model with the SRI Language Modeling Toolkit ([SRILM](http://www.speech.sri.com/projects/srilm/)) is easy. That’s why we
+recommend it. Moreover, SRILM is the most advanced toolkit up to date. To train
+a model you can use the following command:
 
-Training with SRILM is easy.  That's why we recommend it. Morever, SRILM is the 
-most advanced toolkit up to date. To train the model you can use the following 
-command:
-	
     ngram-count -kndiscount -interpolate -text train-text.txt -lm your.lm
 
-You can prune the model afterwards to reduce the size of the model
+You can prune the model afterwards to reduce the size of the model:
 
-	
     ngram -lm your.lm -prune 1e-8 -write-lm your-pruned.lm
 
+After training it is worth it to test the perplexity of the model on the test
+data:
 
-After training it is worth it to test the perplexity of the model on the test data
-
-	
     ngram -lm your.lm -ppl test-text.txt
 
+### Training an ARPA model with CMUCLMTK
 
-### ARPA model training with CMUCLMTK
-
-You need to download and install cmuclmtk. See [download](/wiki/download) for details.
+You need to download and install the language model toolkit for CMUSphinx
+(CMUCLMTK). See the [download page](/wiki/download) for details.
 
 The process for creating a language model is as follows:
 
 1) Prepare a reference text that will be used to generate the language
-model.  The language model toolkit expects its input to be in the form
-of normalized  text files, with utterances delimited by `<s>` and `</s>`
-tags. A number of  input filters are available for specific corpora such
+model. The language model toolkit expects its input to be in the form
+of normalized text files, with utterances delimited by `<s>` and `</s>`
+tags. A number of input filters are available for specific corpora such
 as Switchboard, ISL and  NIST meetings, and HUB5 transcripts. The result
-should be the set of sentences that are bounded by the start and end 
-sentence markers: `<s>` and `</s>`. Here's an example:
+should be the set of sentences that are bounded by the start and end markers of
+the sentence: `<s>` and `</s>`. Here’s an example:
 
-
-```	
-<s> generally cloudy today with scattered outbreaks of rain and drizzle 
+```
+<s> generally cloudy today with scattered outbreaks of rain and drizzle
 persistent and heavy at times </s>
-<s> some dry intervals also with hazy sunshine especially in eastern parts in 
+<s> some dry intervals also with hazy sunshine especially in eastern parts in
 the morning </s>
-<s> highest temperatures nine to thirteen Celsius in a light or moderate mainly 
+<s> highest temperatures nine to thirteen Celsius in a light or moderate mainly
 east south east breeze </s>
-<s> cloudy damp and misty today with spells of rain and drizzle in most places 
-much of this rain will be light and patchy but heavier rain may develop in the 
+<s> cloudy damp and misty today with spells of rain and drizzle in most places
+much of this rain will be light and patchy but heavier rain may develop in the
 west later </s>
 ```
 
-More data will generate better language models. The `weather.txt` file from 
-sphinx4 (used to generate the weather language model) contains nearly 100,000 
+More data will generate better language models. The `weather.txt` file from
+sphinx4 (used to generate the weather language model) contains nearly 100,000
 sentences.
 
 2) Generate the vocabulary file. This is a list of all the words in the file:
-	
+
      text2wfreq < weather.txt | wfreq2vocab > weather.tmp.vocab
 
-3) You may want to edit the vocabulary file to remove words (numbers, 
-misspellings, names). If you find misspellings, it is a good idea to fix them 
+3) You may want to edit the vocabulary file to remove words (numbers,
+misspellings, names). If you find misspellings, it is a good idea to fix them
 in the input transcript.
 
-4) If you want a closed vocabulary language model (a language model that has no 
-provisions for unknown words), then you should remove sentences from your input 
-transcript that contain words that are not in your vocabulary file. 
+4) If you want a closed vocabulary language model (a language model that has no
+provisions for unknown words), then you should remove sentences from your input
+transcript that contain words that are not in your vocabulary file.
 
-5) Generate the arpa format language model with the commands:
+5) Generate the ARPA format language model with the commands:
 
-      text2idngram -vocab weather.vocab -idngram weather.idngram < 
+      text2idngram -vocab weather.vocab -idngram weather.idngram <
 weather.closed.txt
-      idngram2lm -vocab_type 0 -idngram weather.idngram -vocab weather.vocab 
+      idngram2lm -vocab_type 0 -idngram weather.idngram -vocab weather.vocab
 -arpa weather.lm
 
-6) Generate the CMU binary form (BIN)
+6) Generate the CMU binary form (BIN):
 
-	
      sphinx_lm_convert -i weather.lm -o weather.lm.bin
 
+### Building a simple language model using a web service
 
-### Building a simple language model using web service
-
-If your language is English and text is small it's sometimes more convenient to 
-use a web service to build it. Language models built in this way are quite 
-functional for simple command and control tasks. First of all you need to 
+If your language is English and the text is small it’s sometimes more convenient
+to use a web service to build it. Language models built in this way are quite
+functional for simple command and control tasks. First of all you need to
 create a corpus.
 
-The "corpus" is just a list of sentences that you will use to train the 
-language model. As an example,  we will use a hypothetical voice control
-task for a mobile Internet device. We'd like to tell it things like
+The "corpus" is just a list of sentences that you will use to train the
+language model. As an example, we will use a hypothetical voice control
+task for a mobile Internet device. We’d like to tell it things like
 "open browser", "new e-mail", "forward", "backward", "next window",
-"last  window", "open music player", and so forth. So, we'll start by
+"last  window", "open music player", and so forth. So, we’ll start by
 creating a file called `corpus.txt`:
 
-	
 	open browser
 	new e-mail
 	forward
@@ -303,97 +301,93 @@ creating a file called `corpus.txt`:
 	last window
 	open music player
 
-
-Then go to the [LMTool 
+Then go to the [LMTool
 page](http://www.speech.cs.cmu.edu/tools/lmtool-new.html).
-Simply click on the "Browse..." button, select the `corpus.txt` file
-you created, then click "COMPILE KNOWLEDGE BASE".
+Simply click on the *"Browse..."* button, select the `corpus.txt` file
+you created, then click *"COMPILE KNOWLEDGE BASE"*.
 
 You should see a page with some status messages, followed by a page
-entitled  "Sphinx knowledge base". This page will contain links
-entitled "Dictionary" and "Language Model".  Download these files and 
+entitled *"Sphinx knowledge base"*. This page will contain links
+entitled *"Dictionary"* and *"Language Model"*.  Download these files and
 make a note of their names (they should consist of a 4-digit number
 followed by  the extensions  `.dic` and `.lm`). You can now test
 your newly created language model with  PocketSphinx.
 
-### Using other Language Model Toolkits
+### Using other language model toolkits
 
-There are many toolkits that create ARPA n-gram language model from text files.
+There are many toolkits that create an ARPA n-gram language model from text files.
 
 Some toolkits you can try:
 
 * [ IRSLM ](https://sourceforge.net/projects/irstlm/ )
-
 * [ MITLM ](http://code.google.com/p/mitlm/ )
 
 If you are training a large vocabulary speech recognition system, the
-language  model training is outlined in a separate page 
-[tutoriallmadvanced](/wiki/tutoriallmadvanced).
+language model training is outlined in a [separate page about large scale
+language models](/wiki/tutoriallmadvanced).
 
-Once you have created an ARPA file you can convert the model to binary format for 
-faster loading.
+Once you have created an ARPA file you can convert the model to a binary
+format for faster loading.
 
-### Converting model into binary format
+### Converting a model into the binary format
 
 To quickly load large models you probably would like to convert them to
-binary  format that  will save your decoder initialization time. That's
-not necessary with small  models. Pocketsphinx and sphinx3 can handle
-both of them with `-lm` option. Sphinx4 automatically  detects format
-by extension of the lm file.
+a binary format that will save your decoder initialization time. That’s
+not necessary with small models. Pocketsphinx and sphinx3 can handle
+both of them with the `-lm` option. Sphinx4 automatically  detects the format
+by the extension of the lm file.
 
-ARPA format and BINARY format are mutually convertable. You can produce other 
-file with `sphinx_lm_convert` command from sphinxbase:
+The ARPA format and BINARY format are mutually convertable. You can produce
+the other file with the `sphinx_lm_convert` command from sphinxbase:
 
-	
 	sphinx_lm_convert -i model.lm -o model.lm.bin
 	sphinx_lm_convert -i model.lm.bin -ifmt bin -o model.lm -ofmt arpa
 
+You can also convert old DMP models to a binary format this way.
 
-You can also convert old DMP models to bin format this way.
-
-This section will show you how to use, test, and improve the language model you 
-created.
+In the next section we will deal with how to use, test, and improve the language
+model you created.
 
 ### Using your language model with PocketSphinx
 
-If you have installed PocketSphinx, you will have a program called 
-`pocketsphinx_continuous` which can be run from the command-line to
+If you have installed PocketSphinx, you will have a program called
+`pocketsphinx_continuous` which can be run from the command line to
 recognize speech. Assuming it is installed under  `/usr/local`, and your
-language model and dictionary are called `8521.dic`  and `8521.lm` and
-placed in the current folder, try running the following  command:
+language model and dictionary are called `8521.dic` and `8521.lm` and
+placed in the current folder, try running the following command:
 
-	
 	pocketsphinx_continuous -inmic yes -lm 8521.lm -dict 8521.dic
 
+This will use your new language model, the dictionary and the default
+acoustic model. On Windows you also have to specify the acoustic model
+folder with the `-hmm` option:
 
-This will use your new language model and the dictionary and default
-acoustic  model. On Windows you also have to specify the acoustic model
-folder with  `-hmm` option
-
-	
-	bin/Release/pocketsphinx_continuous.exe -inmic yes -lm 8521.lm -dict 
+	bin/Release/pocketsphinx_continuous.exe -inmic yes -lm 8521.lm -dict
 8521.dic -hmm model/en-us/en-us
 
-
-You will see a lot of diagnostic messages, followed by a pause, then 
-"READY...". Now you can try speaking some of the commands. It should be able 
-to recognize them with complete accuracy. If not, you may have problems with 
+You will see a lot of diagnostic messages, followed by a pause, then the output
+*"READY..."*. Now you can try speaking some of the commands. It should be able
+to recognize them with full accuracy. If not, you may have problems with
 your microphone or sound card.
-
 
 ### Using your language model with Sphinx4
 
-In Sphinx4 high-level API you need to specify the location of the language 
-model in Configuration:
+In the Sphinx4 high-level API you need to specify the location of the language
+model in your Configuration:
 
-	
-	configuration.setLanguageModelPath("file:8754.lm");
+```java
+configuration.setLanguageModelPath("file:8754.lm");
+```
 
+If the model is in the resources you can reference it with `"resource:URL"`:
 
-If the model is in resources you can reference it with resource: URL
+```java
+configuration.setLanguageModelPath("resource:/com/example/8754.lm");
+```
 
-	
-	configuration.setLanguageModelPath("resource:/com/example/8754.lm");
+Also see the [Sphinx4 tutorial](/wiki/tutorialsphinx4) for more details.
 
-
-See [Sphinx4 tutorial](/wiki/tutorialsphinx4) for details.
+<span class="post-bottom-nav">
+  [Building a dictionary](/wiki/tutorialdict)
+  [Adapting an existing acoustic model](/wiki/tutorialadapt)
+</span>

--- a/wiki/tutorialoverview.md
+++ b/wiki/tutorialoverview.md
@@ -1,13 +1,12 @@
 ---
-layout: page 
-title: Overview
+layout: page
+title: Overview of the CMUSphinx toolkit
 ---
-# Overview of CMUSphinx toolkit
 
-CMUSphinx toolkit is a leading speech recognition toolkit with various tools 
-used to build speech applications. CMU Sphinx toolkit has a number of packages 
-for different tasks and applications. It’s sometimes confusing what to choose. 
-To cleanup, here is the list:
+The CMUSphinx toolkit is a leading speech recognition toolkit with various tools
+used to build speech applications. CMUSphinx contains a number of packages
+for different tasks and applications. Sometimes, it’s confusing what to choose.
+To shed some light on the parts of the toolkit, here is a list:
 
 * Pocketsphinx — lightweight recognizer library written in C.
 * Sphinxbase — support library required by Pocketsphinx
@@ -34,3 +33,8 @@ The following resources are the main ones for CMUSphinx developers:
 * [Download page](https://sourceforge.net/projects/cmusphinx/files)
 * [Github](https://github.com/cmusphinx)
 * [Telegram Chat](https://t.me/cmusphinx)
+
+<span class="post-bottom-nav">
+  [Basic concepts of speech recognition](/wiki/tutorialconcepts)
+  [Before you start](/wiki/tutorialbeforestart/)
+</span>

--- a/wiki/tutorialpocketsphinx.md
+++ b/wiki/tutorialpocketsphinx.md
@@ -1,247 +1,257 @@
 ---
-layout: page 
-title: Pocketsphinx Tutorial
+layout: page
+title: Building an application with PocketSphinx
 ---
 
+---
 * auto-gen TOC:
 {:toc}
+---
 
-# Building application with pocketsphinx
+> **Caution!**  
+  This tutorial describes pocketsphinx [5 pre-alpha release](https://sourceforge.net/projects/cmusphinx/files/pocketsphinx/5prealpha/).  
+  It is not going to work for older versions.
 
 ## Installation
 
-Pocketsphinx is a library that depends on another library called SphinxBase 
-which provides common functionality 
-across all CMUSphinx projects. To install Pocketsphinx, you need to install 
-both Pocketsphinx and Sphinxbase. It's possible to use Pocketsphinx both in 
-Linux, Windows, on MacOS, iPhone and Android.
+PocketSphinx is a library that depends on another library called SphinxBase
+which provides common functionality across all CMUSphinx projects.
+To install Pocketsphinx, you need to install both Pocketsphinx and Sphinxbase.
+You can use Pocketsphinx with Linux, Windows, on MacOS, iPhone and Android.
 
-First of all, download the released packages pocketsphinx and sphinxbase from 
-project downloads, checkout them from subversion or github. For more details 
-see [ download page](/wiki/download ).
+First of all, download the released packages for pocketsphinx and sphinxbase from
+the projects download page or check them out from Subversion or Github.
 
-Unpack them into same directory. On Windows, you will need to rename 
+For more details see the [download page](/wiki/download).
+
+Unpack them into the same directory. On Windows, you will need to rename
 'sphinxbase-X.Y' (where X.Y is the SphinxBase version number) to simply
-'sphinxbase' to satisfy project pocketsphinx configuration.
+'sphinxbase' to satisfy the project configuration of pocketsphinx.
 
-**THIS TUTORIAL DESCRIBES POCKETSPHINX 5PREALPHA, IT IS NOT GOING TO WORK ON OLDER VERSIONS**
+### Installation on Unix system
 
-### Unix-like Installation
+To build pocketsphinx in a Unix-like environment (such as Linux, Solaris,
+FreeBSD etc.) you need to make sure you have the following dependencies
+installed: gcc, automake, autoconf, libtool, bison, swig (at least version 2.0),
+the Python development package and the pulseaudio development package.
 
-To build pocketsphinx in a unix-like environment (such as Linux, Solaris, 
-FreeBSD etc) you need to make sure you have the following dependencies 
-installed: gcc, automake, autoconf, libtool, bison, swig at least version 2.0, 
-python development package, pulseaudio development package. If you want to 
-build without dependencies you can use proper configure options like 
---without-swig-python but for beginner it is recommended to install all 
-dependencies.
+If you want to build it without some dependencies you can use the respective
+configuration options like `--without-swig-python`. However, for beginners it’s
+recommended to install all dependencies.
 
-You need to download both sphinxbase and pocketsphinx packages and unpack them. 
-Please note that you can not use sphinxbase and pocketsphinx of different 
-version, please make sure that versions are in sync. After unpack you should 
-see the following two main folders:
+You need to download both the sphinxbase and pocketsphinx packages and unpack them.
+Please note that you cannot use sphinxbase and pocketsphinx of different
+version. So, please make sure that their versions are in sync. After unpacking,
+you should see the following two main folders:
 
 ```
 sphinxbase-X.X
 pocketsphinx-X.x
 ```
 
-On step one, build and install SphinxBase. Change current directory to 
-`sphinxbase` folder. If you downloaded directly from the repository, you need 
-to do this at least once to generate the `configure` file:
+First, build and install SphinxBase. Change the current directory to the
+`sphinxbase` folder. If you downloaded it directly from the repository, you need
+to run the following command at least once to generate the `configure` file:
 
-```
-# ./autogen.sh
-```
-
-if you downloaded the release version, or ran `autogen.sh` at least once, 
-then compile and install:
-
-```
-# ./configure
-# make
-# make install
+```bash
+./autogen.sh
 ```
 
-The last step might require root permissions so it might be `sudo make 
-install`. If you want to use fixed-point arithmetic, you must configure 
-SphinxBase with the --enable-fixed option. You can also set installation prefix 
-with `--prefix`. You can also configure with or without SWIG python support.
+If you downloaded the release version, or ran `autogen.sh` at least once, then
+compile and install it with:
 
-The sphinxbase will be installed in `/usr/local/` folder by default. Not 
-every system loads libraries from this folder automatically. To load them you 
-need to configure the path to look for shared libaries. It can be done either 
-in the file `/etc/ld.so.conf` or with exporting environment variables:
-
+```bash
+./configure
+make
+make install
 ```
+
+The last step might require root permissions, so you might need to run `sudo make
+install`. If you want to use fixed-point arithmetic, you must configure
+SphinxBase with the `--enable-fixed` option. You can also set an installation prefix
+with `--prefix` or configure to use or not to use SWIG Python support.
+
+Sphinxbase will be installed in the `/usr/local/` directory by default. Not
+all systems load libraries from this folder automatically. In order to load
+them you need to configure the path to look for shared libaries. This can be done
+either in the `/etc/ld.so.conf` file or by exporting the environment variables:
+
+```bash
 export LD_LIBRARY_PATH=/usr/local/lib
 export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
 ```
-     
-For more details on linker configuration see [Shared Libraries 
+
+For more details on the linker configuration see the [Shared Libraries
 HOWTO](http://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html).
 
-Then change to pocketsphinx folder and perform the same steps
+Then change to the pocketsphinx folder and perform the same steps:
 
+```bash
+./configure
+make
+make install
 ```
-# ./configure
-# make
-# make install
-```
 
-To test installation, run `'pocketsphinx_continuous -inmic yes`' and check 
-that it recognizes words you are saying to the microphone.
+To test the installation, run `pocketsphinx_continuous -inmic yes` and check
+that it recognizes words you speak into your microphone.
 
-If you get an error such as: `error while loading shared libraries: 
-libpocketsphinx.so.3`, you may want to check your linker configuration with 
-LD_LIBRARY_PATH environment variable described above.
+If you get an error such as: `error while loading shared libraries:
+libpocketsphinx.so.3`, you may want to check your linker configuration of the
+`LD_LIBRARY_PATH` environment variable described above.
 
 ### Windows
 
-In MS Windows (TM), under MS Visual Studio 2010 (or newer - we test with Visual 
+In MS Windows, under MS Visual Studio 2010 (or newer – we test with Visual
 C++ 2010 Express):
 
-  *  load sphinxbase.sln located in sphinxbase directory
+  *  load `sphinxbase.sln` in the sphinxbase directory
   *  compile all the projects in SphinxBase (from `sphinxbase.sln`)
-  *  load `pocketsphinx.sln` in pocketsphinx directory
+  *  load `pocketsphinx.sln` in the pocketsphinx directory
   *  compile all the projects in PocketSphinx
 
-MS Visual Studio will build the executables and libraries under 
+MS Visual Studio will build the executables and libraries under
 `.\bin\Release` or `.\bin\Debug` (depending on the target you choose on
-MS  Visual Studio). To run `pocketsphinx_continuous.exe`, don't forget
-to copy  sphinxbase.dll to the bin folder. Otherwise the executable will
-fail to find  this library. Unlike on Linux, the path to the model is
-not preconfigured in  Windows, so you have to specify
-pocketsphinx_continuous where to find the model  with `-hmm`, `-lm` and
-`-dict` options. Change to pocketsphinx folder and run
+MS  Visual Studio). In order to run `pocketsphinx_continuous.exe`, don’t forget
+to copy the sphinxbase.dll file to the bin folder. Otherwise the executable will
+fail to find this library. Unlike on Linux, the path to the model is not
+preconfigured in Windows, so you have to specify for pocketsphinx_continuous
+where to find the model  with the `-hmm`, `-lm` and `-dict` options.
 
-```
+To recognize speech from your microphone, change to the pocketsphinx folder and
+run:
+
+```bash
 bin\Release\Win32\pocketsphinx_continuous.exe -inmic yes
-    -hmm model\en-us\en-us -lm model\en-us\en-us.lm.bin 
+    -hmm model\en-us\en-us -lm model\en-us\en-us.lm.bin
     -dict model\en-us\cmudict-en-us.dict
 ```
 
-to recognize from microphone. To recognize from file run
+To recognize speech from a file run:
 
-```
-bin\Release\Win32\pocketsphinx_continuous.exe -infile test\data\goforward.raw 
-    -hmm model\en-us\en-us -lm model\en-us\en-us.lm.bin 
+```bash
+bin\Release\Win32\pocketsphinx_continuous.exe -infile test\data\goforward.raw
+    -hmm model\en-us\en-us -lm model\en-us\en-us.lm.bin
     -dict model\en-us\cmudict-en-us.dict
 ```
 
-## Pocketsphinx API Core Ideas
+## Pocketsphinx API core ideas
 
-Pocketsphinx API is designed to ease the use of speech recognizer functionality 
-in your applications
+The Pocketsphinx API is designed to ease the use of speech recognizer
+functionality in your applications:
 
-  1. It is much more likely to remain stable both in terms of source and binary compatibility, due to the use of abstract types.
-  1. It is fully re-entrant, so there is no problem having multiple decoders in the same process.
-  1. It has enabled a drastic reduction in code footprint and a modest but significant reduction in memory consumption.
+  1. It is very likely to remain stable both in terms of source and binary
+     compatibility, due to the use of abstract types.
+  2. It is fully re-entrant, so there is no problem having multiple decoders in
+     the same process.
+  3. It allows a drastic reduction in code footprint and a modest but
+     significant reduction in memory consumption.
 
-Reference documentation for the new API is available at <https://cmusphinx.github.io/doc/pocketsphinx/>
+The reference documentation for the new API is available at <https://cmusphinx.github.io/doc/pocketsphinx/>.
 
-## Basic Usage (hello world)
+## Basic usage (hello world)
 
-There are few key things you need to know on how to use the API:
+There are a few key things you need to know when you want to use the API:
 
-  1. Command-line parsing is done externally (in `<cmd_ln.h>`)
-  1. Everything takes a `ps_decoder_t *` as the first argument.
+  1. command-line parsing is done externally (in `<cmd_ln.h>`)
+  2. everything takes a `ps_decoder_t *` as the first argument
 
-To illustrate the API, we will step through a simple "hello world"
-example.This example is somewhat specific to Unix in the locations of
-files and the compilation process.  We will create a C source file
-called `hello_ps.c`. To compile it (on Unix), use this command:
+To illustrate the API, we will step through a simple "hello world" example.
+This example is somewhat specific to Unix regarding the locations of files and
+the compilation process. We will create a C source file called `hello_ps.c`.
+To compile it (on Unix), use this command:
 
-```	
+```bash
 gcc -o hello_ps hello_ps.c \
     -DMODELDIR=\"`pkg-config --variable=modeldir pocketsphinx`\" \
     `pkg-config --cflags --libs pocketsphinx sphinxbase`
 ```
 
-Please note that compilation errors here mean that you didn't carefully
-read  the tutorial and didn't follow the installation guide above. For
-example  pocketsphinx needs to be properly installed to be available
-through pkg-config  system. To check that pocketsphinx is installed
-properly, just run `pkg-config --cflags --libs pocketsphinx sphinxbase`
-from the command line and see that output looks like
+Please note that compilation errors mean that you didn’t carefully follow the
+installation guide above. For example pocketsphinx needs to be properly
+installed to be available through the pkg-config system. To check whether
+pocketsphinx is installed properly, just run
 
+```bash
+pkg-config --cflags --libs pocketsphinx sphinxbase
 ```
+on the command line and make sure the output looks like this:
+
+```bash
 -I/usr/local/include -I/usr/local/include/sphinxbase -I/usr/local/include/pocketsphinx  
 	-L/usr/local/lib -lpocketsphinx -lsphinxbase -lsphinxad
 ```
 
 ### Initialization
 
-The first thing we need to do is to create a configuration object, which for 
-historical reasons is called `cmd_ln_t`. Along with the general boilerplate 
-for our C program, we will do it like this:
+The first thing we need to do is to create a configuration object, which for
+historical reasons is called `cmd_ln_t`. Along with the general boilerplate
+for our C program, our code looks like this:
 
-```	
+```c
 #include <pocketsphinx.h>
-	
+
 int
 main(int argc, char *argv[])
 {
     ps_decoder_t *ps = NULL;
     cmd_ln_t *config = NULL;
-	
+
     config = cmd_ln_init(NULL, ps_args(), TRUE,
 		         "-hmm", MODELDIR "/en-us/en-us",
 	                 "-lm", MODELDIR "/en-us/en-us.lm.bin",
 	                 "-dict", MODELDIR "/en-us/cmudict-en-us.dict",
 	                 NULL);
-	
+
     return 0;
 }
 ```
 
-The `cmd_ln_init()` function takes a variable number of null-terminated 
-string arguments, followed by NULL. The first argument is any previous 
-`cmd_ln_t *` which is to be updated. The second argument is an array of 
-argument definitions - the standard set can be obtained by calling 
+The `cmd_ln_init()` function takes a variable number of null-terminated
+string arguments, followed by NULL. The first argument is any previous
+`cmd_ln_t *` which is to be updated. The second argument is an array of
+argument definitions – the standard set can be obtained by calling
 `ps_args()`. The third argument is a flag telling the argument parser to
-be  "strict" - if this is `TRUE`, then duplicate arguments or unknown
-arguments  will cause parsing to fail.
+be "strict". If this argument is `TRUE`, then duplicate arguments or unknown
+arguments will cause the parsing process to fail.
 
-The `MODELDIR` macro is defined on the GCC command-line by using 
-`pkg-config` to obtain the `modeldir` variable from PocketSphinx 
+The `MODELDIR` macro is defined on the GCC command-line by using the
+`pkg-config` to obtain the `modeldir` variable from the PocketSphinx
 configuration. On Windows, you can simply add a preprocessor definition
 to the code, such as this:
 
-```	
+```c
 #define MODELDIR "c:/sphinx/model"
 ```
 
-(replace this with wherever your models are installed). Now, to
-initialize the  decoder, use `ps_init`:
+(replace this with wherever your models are installed). In order to
+initialize the decoder, use `ps_init`:
 
-```
+```c
 ps = ps_init(config);
 ```
 
 ### Decoding a file stream
 
-Because live audio input is somewhat platform-specific, we will confine 
-ourselves to decoding audio files. There is an audio file helpfully
-included in the PocketSphinx source code which contains this very
-sentence. You can find it in `pocketsphinx/test/data/goforward.raw`.
-Copy it to the current directory. If you want to  create your own
-version of it, it needs to be a single-channel (monaural),
-little-endian, unheadered 16-bit signed PCM audio file sampled at 16000
-Hz.
+Because live audio input is somewhat platform-specific, we will confine
+ourselves to decoding audio files. There is an audio file helpfully included in
+the pocketsphinx source code which contains this very sentence. You can find it
+in `pocketsphinx/test/data/goforward.raw`.
+Copy it to the current directory. If you want to create your own version of it:
+it needs to be a single-channel (monaural), little-endian, unheadered 16-bit
+signed PCM audio file sampled at 16000 Hz.
 
-Main pocketsphinx use case is to read audio data in blocks of memory
-from somewhere and feed them to the decoder. To do that we first open
-the file and  start decoding of the utterance using `ps_start_utt()`:
+The main pocketsphinx use case is to read audio data in blocks of memory
+from a source and feed it to the decoder. To do that, we first open the file and
+start decoding the utterance using `ps_start_utt()`:
 
-```	
+```c
 rv = ps_start_utt(ps);
 ```
 
-We will then read 512 samples at a time from the file, and feed them to
-the decoder using `ps_process_raw()`:
+Next, we read 512 samples at a time from the file, and feed them to the decoder
+using `ps_process_raw()`:
 
-```
+```c
 int16 buf[512];
 while (!feof(fh)) {
     size_t nsamp;
@@ -250,32 +260,34 @@ while (!feof(fh)) {
 }
 ```
 
-Then we will need to mark the end of the utterance using `ps_end_utt()`:
+Afterwards, we need to mark the end of the utterance using `ps_end_utt()`:
 
-```	
+```c
     rv = ps_end_utt(ps);
 ```
 
-Then we retrieve the hypothesis to get recognition result
+Last, we retrieve the hypothesis to get our recognition result:
 
-```	
+```c
     hyp = ps_get_hyp(ps, &score);
     printf("Recognized: %s\n", hyp);
 ```
 
-We can also retrieve the hypothesis during recognition, it will return partial 
-result.
+We can also retrieve the hypothesis during recognition. If we do so, it will
+return a partial result.
 
 ### Cleaning up
 
-To clean up, simply call `ps_free()` on the object that was returned by 
-`ps_init()`. Free the configuration object with cmd_ln_free_r.
+To clean up, simply call `ps_free()` on the object that was returned by
+`ps_init()`. Free the configuration object with `cmd_ln_free_r`.
 
 ### Full code listing
 
-```
+Here is the full listing of our code again:
+
+```c
 #include <pocketsphinx.h>
-	
+
 int
 main(int argc, char *argv[])
 {
@@ -296,80 +308,84 @@ main(int argc, char *argv[])
 	fprintf(stderr, "Failed to create config object, see log for details\n");
 	return -1;
     }
-	  
+
     ps = ps_init(config);
     if (ps == NULL) {
 	fprintf(stderr, "Failed to create recognizer, see log for details\n");
 	return -1;
     }
-	
+
     fh = fopen("goforward.raw", "rb");
     if (fh == NULL) {
 	fprintf(stderr, "Unable to open input file goforward.raw\n");
 	return -1;
     }
-	
+
     rv = ps_start_utt(ps);
-	  
+
     while (!feof(fh)) {
 	size_t nsamp;
 	nsamp = fread(buf, 2, 512, fh);
 	rv = ps_process_raw(ps, buf, nsamp, FALSE, FALSE);
     }
-	  
+
     rv = ps_end_utt(ps);
     hyp = ps_get_hyp(ps, &score);
     printf("Recognized: %s\n", hyp);
-	
+
     fclose(fh);
     ps_free(ps);
     cmd_ln_free_r(config);
-	  
+
     return 0;
 }
-```	
+```
 
+## Advanced usage
 
-## Advanced Usage
+For more advanced uses of the API please check the API reference.
 
-For more complicated uses of the API please check the API reference.
+* For word segmentations, the API provides an iterator object which is
+  used to iterate over the sequence of words. This iterator object is an
+  abstract type, with some accessors provided to obtain timepoints, scores and,
+  most interestingly, posterior probabilities for each word.
+* The confidence of the whole utterance can be accessed with the `ps_get_prob` method.
+* You can access the lattice if needed.
+* You can configure multiple searches and switch between them in runtime.
 
-  * For word segmentations, the API provides an iterator object which is
-  used to, well, iterate over the sequence of words. This iterator
-  object is an abstract type, with some accessors provided to obtain
-  timepoints, scores, and (most interestingly) posterior probabilities
-  for each word.
-  * Confidence of the whole utterance can be accessed with ps_get_prob method.
-  * You can access lattice if needed
-  * You can configure multiple searches and switch between them in runtime.
+### Searches
 
-### Searches 
+As a developer you can configure several "search" objects with different
+grammars and language models and switch between them during runtime to provide
+interactive experience for the user.
 
-Developer can configure several "search" objects with different grammars and 
-language models and switch them in runtime to provide interactive experience 
-for the user.
+There are multiple possible search modes:
 
-There are different possible search modes:
-  * keyword - efficiently looks for keyphrase and ignores other speech. allows 
-to configure detection threshold.
-  * grammar - recognizes speech according to JSGF grammar. Unlike keyphrase 
-grammar search doesn't ignore words which are not in grammar but tries to 
-recognize them.
-  * ngram/lm - recognizes natural speech with a language model.
-  * allphone - recognizes phonemes with a phonetic language model.
+* *keyword*: efficiently looks for a keyphrase and ignores other speech.
+  It Allows to configure the detection threshold.
+* *grammar*: recognizes speech according to the JSGF grammar. Unlike keyphrase
+  search, grammar search doesn’t ignore words which are not in the grammar but
+  tries to recognize them.
+* *ngram/lm*: recognizes natural speech with a language model.
+* *allphone*: recognizes phonemes with a phonetic language model.
 
-Each search has a name and can be referenced by a name, names are 
-application-specific. The function ps_set_search allows to activate the
-search previously added by a name. 
+Each search has a name and can be referenced by a name. Names are
+application-specific. The function `ps_set_search` allows to activate the
+search that was previously added by a name.
 
-To add the search one needs to point to the grammar/language model describing 
-the search. The location of the grammar is specific to the application. If only 
-a simple recognition is required it is sufficient to add a single search or 
-just configure the required mode with configuration options.
+In order to add a search, one needs to point to the grammar/language model
+describing the search. The location of the grammar is specific to the application.
+If only a simple recognition is required it is sufficient to add a single search
+or to just configure the required mode using configuration options.
 
-The exact design of a searches depends on your application. For example, you 
-might want to listen for activation keyword first and once keyword is 
-recognized switch to ngram search to recognize actual command. Once you 
-recognized the command you can switch to grammar search to recognize the 
-confirmation and then switch back to keyword listening mode to wait for another 
+The exact design of a search depends on your application. For example, you
+might want to listen for an activation keyword first and once this keyword is
+recognized switch to ngram search to recognize the actual command. Once you
+recognized the command you can switch to grammar search to recognize the
+confirmation and then switch back to keyword listening mode to wait for another
 command.
+
+<span class="post-bottom-nav">
+  [Building an application with Sphinx4](/wiki/tutorialsphinx4)
+  [Using PocketSphinx on Android](/wiki/tutorialandroid)
+</span>

--- a/wiki/tutorialsphinx4.md
+++ b/wiki/tutorialsphinx4.md
@@ -1,47 +1,54 @@
 ---
-layout: page 
-title: Sphinx4 tutorial
+layout: page
+title: Building an application with sphinx4
 ---
 
-WARNING: THIS TUTORIAL DESCRIBES SPHINX4 API FROM THE [5 PRE-ALPHA RELEASE](https://sourceforge.net/projects/cmusphinx/files/sphinx4/5prealpha/)
+---
 
-**The API described here is not supported in earlier versions**
+* auto-gen TOC:
+{:toc}
+
+---
+
+> **Caution!**  
+  This tutorial uses the sphinx4 API from the [5 pre-alpha release](https://sourceforge.net/projects/cmusphinx/files/sphinx4/5prealpha/).  
+  The API described here is not supported in earlier versions.
 
 ## Overview
 
-Sphinx4 is a pure Java speech recognition library. It provides a quick and easy 
-API to convert the speech recordings into text with the help CMUSphinx acoustic 
-models. It can be used on servers and in desktop applications. Beside speech 
-recognition Sphinx4 helps to identify speakers, adapt models, align existing 
-transcription to audio for timestamping and more.
+Sphinx4 is a pure Java speech recognition library. It provides a quick and easy
+API to convert the speech recordings into text with the help of CMUSphinx
+acoustic models. It can be used on servers and in desktop applications. Besides
+speech recognition, Sphinx4 helps to identify speakers, to adapt models, to
+align existing transcription to audio for timestamping and more.
 
 Sphinx4 supports US English and many other languages.
 
-## Using in your projects
+## Using sphinx4 in your projects
 
-As any library in Java all you need to do to use sphinx4 is to add jars into 
-dependencies of your project and then you can write code using the API.
+As any library in Java all you need to do to use sphinx4 is to add the jars to
+the dependencies of your project and then you can write code using the API.
 
-The easiest way to use modern sphinx4 is to use modern build tools like [ 
-Apache Maven](http://maven.apache.org/ref/3.1.0/ ) or [ 
-Gradle](http://gradle.org). Sphinx-4 is available as a maven package in [ 
-Sonatype OSS repository](https://oss.sonatype.org/ ). 
+The easiest way to use sphinx4 is to use modern build tools like [
+Apache Maven](http://maven.apache.org/ref/3.1.0/ ) or [
+Gradle](http://gradle.org). Sphinx-4 is available as a maven package in the [
+Sonatype OSS repository](https://oss.sonatype.org/ ).
 
-In gradle you need to following lines in `build.gradle`
+In gradle you need the following lines in `build.gradle`:
 
 ```
 repositories {
     mavenLocal()
     maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
 }
-	
+
 dependencies {
     compile group: 'edu.cmu.sphinx', name: 'sphinx4-core', version:'5prealpha-SNAPSHOT'
     compile group: 'edu.cmu.sphinx', name: 'sphinx4-data', version:'5prealpha-SNAPSHOT'
 }
 ```
 
-To use sphinx4 in your  maven project specify this repository in your `pom.xml`:
+To use sphinx4 in your maven project specify this repository in your `pom.xml`:
 
 ```
 <project>
@@ -72,7 +79,7 @@ Then add `sphinx4-core` to the project dependencies:
 </dependency>
 ```
 
-Add `sphinx4-data` to dependencies as well if you want to use default 
+Add `sphinx4-data` to the dependencies as well if you want to use the default
 US English acoustic and language models:
 
 ```
@@ -83,32 +90,31 @@ US English acoustic and language models:
 </dependency>
 ```
 
-Many IDEs like Eclipse or Netbeans or Idea have support for Gradle
-either with  plugin or with built-in features. In that case you can just
-include sphinx4  libraries into your project with the help of IDE.
-Please check the relevant  part of your IDE documentation, for example 
+Many IDEs like Eclipse, Netbeans or Idea have support for Gradle
+either through plugins or with built-in features. In that case you can just
+include sphinx4 libraries into your project with the help of your IDE.
+Please check the relevant part of your IDE documentation, for example the
 [IDEA documentation on Gradle](https://www.jetbrains.com/idea/help/gradle.html).
 
-You can also use Sphinx4 in non-maven project, in that case you need to 
-download jars from the
-[repository](https://oss.sonatype.org/#nexus-search) manually. You also
-might need to download the dependencies (which we try to keep small) and
-include  them into your project. You need sphinx4-core jar and
-sphinx4-data jar if you are going to use US English acoustic model. See
-below
+You can also use Sphinx4 in a non-maven project. In this case you need to
+download the jars from the
+[repository](https://oss.sonatype.org/#nexus-search) manually. You might also
+need to download the dependencies (which we try to keep small) and
+include  them in your project. You need the *sphinx4-core* jar and the
+*sphinx4-data* jar if you are going to use US English acoustic model:
 
 ![Sphinx4 jar download](/data/sphinx4-download.png)
 
-Here is for example how to include jars into eclipse:
+Here is an example for how to include the jars in Eclipse:
 
 ![Include Jar into Eclipse project](/data/sphinx4-eclipse-include-jar.png)
 
 ## Basic Usage
 
-To quickly start with sphinx4, create a java project as described above, add 
-required dependencies and type the following simple code:
+To quickly start with sphinx4, create a java project as described above, add
+the required dependencies and type the following simple code:
 
-```	
+```java
 package com.example;
 
 import java.io.File;
@@ -120,7 +126,7 @@ import edu.cmu.sphinx.api.SpeechResult;
 import edu.cmu.sphinx.api.StreamSpeechRecognizer;
 
 public class TranscriberDemo {       
-                                     
+
     public static void main(String[] args) throws Exception {
 
         Configuration configuration = new Configuration();
@@ -131,7 +137,7 @@ public class TranscriberDemo {
 
 	StreamSpeechRecognizer recognizer = new StreamSpeechRecognizer(configuration);
 	InputStream stream = new FileInputStream(new File("test.wav"));
-	
+
         recognizer.startRecognition(stream);
 	SpeechResult result;
         while ((result = recognizer.getResult()) != null) {
@@ -142,34 +148,35 @@ public class TranscriberDemo {
 }
 ```
 
-This simple code transcribes file test.wav, just make sure it exists in the 
-project root.
+This simple code snippet transcribes the file `test.wav` – just make sure it
+exists in the project root.
 
-There are several high-level recognition interfaces in Sphinx-4:
+There are several high-level recognition interfaces in sphinx4:
 
   *  LiveSpeechRecognizer
   *  StreamSpeechRecognizer
   *  SpeechAligner
 
-For the most of the speech recognition jobs high-levels interfaces should be 
-enough. And basically you will have only to setup four attributes:
+For most of the speech recognition jobs high-level interfaces should be
+sufficient. Basically, you will only have to setup four attributes:
 
-  *  Acoustic model.
-  *  Dictionary.
-  *  Grammar/Language model.
-  *  Source of speech.
+  *  Acoustic model
+  *  Dictionary
+  *  Grammar/Language model
+  *  Source of speech
 
-First three attributes are setup using Configuration object which is passed 
-then to a recognizer. The way to point out to the speech source depends on a 
-concrete recognizer and usually is passed as a method parameter.
+The first three attributes are set up using a `Configuration` object which is
+then passed to a recognizer. The way to connect to a speech source depends on
+your concrete recognizer and usually is passed as a method parameter.
 
 ### Configuration
 
-Configuration is used to supply required and optional attributes to recognizer.
+A `Configuration` is used to supply the required and optional attributes
+to the recognizer.
 
-```
+```java
 Configuration configuration = new Configuration();
-	
+
 // Set path to acoustic model.
 configuration.setAcousticModelPath("resource:/edu/cmu/sphinx/models/en-us/en-us");
 // Set path to dictionary.
@@ -180,10 +187,10 @@ configuration.setLanguageModelPath("resource:/edu/cmu/sphinx/models/en-us/en-us.
 
 ### LiveSpeechRecognizer
 
-LiveSpeechRecognizer uses microphone as the speech source.
+The `LiveSpeechRecognizer` uses a microphone as the speech source.
 
 
-```
+```java
 LiveSpeechRecognizer recognizer = new LiveSpeechRecognizer(configuration);
 // Start recognition process pruning previously cached data.
 recognizer.startRecognition(true);
@@ -194,43 +201,41 @@ recognizer.stopRecognition();
 
 ### StreamSpeechRecognizer
 
-StreamSpeechRecognizer uses InputStream as the speech source, you can
-pass the data from the file this way, you can pass the data from the
-network socket or  from existing byte array.
+The `StreamSpeechRecognizer` uses an `InputStream` as the speech source. You can
+pass the data from a file, a network socket or from an existing byte array.
 
-```
+```java
 StreamSpeechRecognizer recognizer = new StreamSpeechRecognizer(configuration);
 recognizer.startRecognition(new FileInputStream("speech.wav"));
+
 SpeechResult result = recognizer.getResult();
 recognizer.stopRecognition();
 ```
 
-
-Please note that the audio for this decoding must have one of the two specific 
+Please note that the audio for this decoding must have one of the following
 formats:
 
 ```
 RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 16000 Hz
 ```
-
 or
 
 ```
 RIFF (little-endian) data, WAVE audio, Microsoft PCM, 16 bit, mono 8000 Hz
 ```
 
-Decoder does not support other formats. If audio format does not match, you 
-will not get any results. You need to convert audio to a proper format before 
-decoding. If you want to decode telephone quality audio with the sample rate 
-8000 Hz, you also need to call
+The decoder does not support other formats. If the audio format does not match,
+you will not get any results. This means, you need to convert your audio to a
+proper format before decoding. E.g. if you want to decode audio in telephone
+quality with a sample rate of 8000 Hz, you would need to call
 
-```
+```java
 configuration.setSampleRate(8000);
 ```
 
-You can retreive multiple results until the file end:
+You can retreive multiple results until the end of the file is reached:
 
-```	
+```java
 while ((result = recognizer.getResult()) != null) {
     System.out.println(result.getHypothesis());
 }
@@ -238,62 +243,67 @@ while ((result = recognizer.getResult()) != null) {
 
 ### SpeechAligner
 
-SpeechAligner time-aligns text with audio speech.
+A `SpeechAligner` time-aligns text with audio speech.
 
-```
+```java
 SpeechAligner aligner = new SpeechAligner(configuration);
 recognizer.align(new URL("101-42.wav"), "one oh one four two");
 ```
 
 ### SpeechResult
 
-SpeechResult provides access to various parts of the recognition result, such 
-as recognized utterance, list of words with time stamps, recognition lattice 
-and so forth.
+A `SpeechResult` provides access to various parts of the recognition result,
+such as the recognized utterance, a list of words with timestamps, the
+recognition lattice, etc.:
 
-```
+```java
 // Print utterance string without filler words.
 System.out.println(result.getHypothesis());
-	
+
 // Get individual words and their times.
 for (WordResult r : result.getWords()) {
     System.out.println(r);
 }
-	
+
 // Save lattice in a graphviz format.
 result.getLattice().dumpDot("lattice.dot", "lattice");
 ```
 
 ## Demos
 
-A number of sample demos are included in sphinx4 sources in order to give you 
-understanding how to run Sphinx4. You can run them from sphinx4-samples jar:
+A number of sample demos are included in the sphinx4 sources in order to give
+you an understanding how to run sphinx4. You can run them from the
+sphinx4-samples jar:
 
    * [Transcriber](https://github.com/cmusphinx/sphinx4/blob/master/sphinx4-samples/src/main/java/edu/cmu/sphinx/demo/transcriber/TranscriberDemo.java ) - demonstrates how to transcribe a file
-   * [Dialog](https://github.com/cmusphinx/sphinx4/blob/master/sphinx4-samples/src/main/java/edu/cmu/sphinx/demo/dialog/DialogDemo.java ) - demonstrates how to lead dialog with a user
+   * [Dialog](https://github.com/cmusphinx/sphinx4/blob/master/sphinx4-samples/src/main/java/edu/cmu/sphinx/demo/dialog/DialogDemo.java ) - demonstrates how to lead a dialog with a user
    * [SpeakerID](https://github.com/cmusphinx/sphinx4/blob/master/sphinx4-samples/src/main/java/edu/cmu/sphinx/demo/speakerid/SpeakerIdentificationDemo.java) - speaker identification
    * [Aligner](https://github.com/cmusphinx/sphinx4/blob/master/sphinx4-samples/src/main/java/edu/cmu/sphinx/demo/aligner/AlignerDemo.java ) - demonstration of audio to transcription timestamping
 
-If you are going to start with a demo please do not modify the demo inside 
-sphinx4 sources, instead copy the code into your project and modify it there.
+If you are going to start with a demo please do not modify the demo inside
+the sphinx4 sources. Instead, copy the code into your project and modify it there.
 
 ## Building from source
 
-If you want to develop Sphinx4 itself you might want to build it from
-source.  Sphinx4 uses [Gradle](http://gradle.org) build system. Simply
-type 'gradle  build' in the top folder, it will compile and install
-everything including  dependencies.
+If you want to develop sphinx4 itself you might want to build it from source.  
+Sphinx4 uses the [Gradle](http://gradle.org) build system. In order to compile
+and install everything, including the dependencies, simply type 'gradle  build'
+in the root directory.
 
-If you are going to use IDE, make sure it supports Gradle projects, then simply 
-import sphinx4 source tree.
+If you are going to use an IDE, make sure it supports Gradle projects. Then
+simply import the sphinx4 source tree.
 
 ## Troubleshooting
 
-You might meet different problems while using sphinx4, please check the 
-[FAQ](/wiki/faq) first before asking them on the forum.
+You might experience the one or the other problem while using sphinx4. Please
+check the [FAQ](/wiki/faq) first before asking any new questions on the forum.
 
-In case you have issues with accuracy you need to provide audio
-recording you  are trying to recognize, all the models you use and
-describes how results you  see are different from your expectation.
+In case you have issues with the accuracy, you need to provide the audio
+recording you are trying to recognize along with all models you use.
+Additionally, you need to describe in which way your results differ from your
+expectations.
 
- 
+<span class="post-bottom-nav">
+  [Before you start](/wiki/tutorialbeforestart)
+  [Building an application with pocketsphinx](/wiki/tutorialpocketsphinx)
+</span>

--- a/wiki/tutorialtuning.md
+++ b/wiki/tutorialtuning.md
@@ -1,116 +1,136 @@
 ---
-layout: page 
+layout: page
 title: Tuning speech recognition accuracy
 ---
-# Tuning speech recognition accuracy
+
+---
+* auto-gen TOC:
+{:toc}
+---
 
 Speech recognition accuracy is not always great.
 
-The first thing you need to understand if your accuracy just lower than 
-expected or very low. If it's very low most likely you misconfigured the 
-decoder. If it's lower than expected, you can apply various ways to improve it.
+First, it is important to understand whether your accuracy is just lower than
+expected or whether it is very low in general. If the accuracy is very low in
+general, you most likely misconfigured the decoder. If it is lower than
+expected, you can apply various ways to improve it.
 
-The first thing you should do is to collect a database of test samples and 
-measure the recognition accuracy. You need to dump utterances into wav files, 
-write reference text and use decoder to decode it. Then calculate WER using the 
-`word_align.pl` tool from Sphinxtrain. Test database size depends on the accuracy 
-but usually it's enough to have 30 minutes of transcribed audio to test 
-recognizer accuracy reliably.
+The first thing you should do is to collect a database of test samples and
+measure the recognition accuracy. You need to dump utterances into wav files,
+write a reference text and use the decoder to decode it. Then calculate the
+Word Error Rate (WER) using the `word_align.pl` tool from Sphinxtrain.
+The size of the test database depends on the accuracy but usually it’s
+sufficient to have 30 minutes of transcribed audio to test recognizer accuracy
+reliably.
 
-Only if you have a test database you can proceed with recognition accuracy 
-optimization.
+Only if you have a test database you can proceed with optimizing the recognition
+accuracy.
 
-The top reasons of the bad accuracy are:
+## Reasons for bad accuracy
 
-* The mismatch of the sample rate/no. of channels of the incoming audio or the 
-mismatch of the incoming audio bandwidth. It must be 16kHz (or 8kHz, depending 
-on the training data) 16bit Mono (= single channel) Little-Endian file. You 
-need to fix sample rate of the source with resampling (only if its rate is 
-higher than that of the training data). You should not upsample a file and 
-decode it with acoustic models trained on higher sampling rate audio. Audio 
-file format (sampling rate, number of channels) can be verified using below 
-command `sox --i /path/to/audio/file`. Find more information here: 
-[What is sample rate](/wiki/faq#q-what-is-sample-rate-and-how-does-it-affect-accuracy) 
+The top reasons for a bad accuracy are:
 
-* The mismatch of the acoustic model. To verify this hypothesis you need to 
-construct a language model from the test database text. Such language model 
-will be very good and must give you a high accuracy. If accuracy is still low, 
-you need to work more on the acoustic model. You can use acoustic model 
-adaptation to improve accuracy
+* The mismatch of the sample rate and the number of channels of the incoming
+audio or the mismatch of the incoming audio bandwidth. It must be a 16 kHz
+(or 8 kHz, depending on the training data), 16bit Mono (= single channel)
+Little-Endian file.
+You need to fix the sample rate of the source with resampling (only if its rate
+is higher than that of the training data). You should not upsample a file and
+decode it with acoustic models trained on audio with a higher sampling rate.
+The audio file format (sampling rate, number of channels) can be verified using
+the command
 
-* The mismatch of the langauge model. You can create your own langauge model 
+  ```
+  sox --i /path/to/audio/file
+  ```
+Find more information here:
+[What is sample rate?](/wiki/faq#q-what-is-sample-rate-and-how-does-it-affect-accuracy)
+
+* The mismatch of the acoustic model. To verify this hypothesis you need to
+construct a language model from the test database text. Such a language model
+will be very good and must give you a high accuracy. If accuracy is still low,
+you need to work more on the acoustic model. You can use acoustic model
+adaptation to improve accuracy.
+
+* The mismatch of the langauge model. You can create your own language model
 to match the vocabulary you are trying to decode.
 
-* The mismatch in the dictionary and the pronuncation of the words. In that 
-case a work must be done on the phonetic dictionary.
+* The mismatch in the dictionary and the pronuncation of the words. In that
+case some work must be done in the phonetic dictionary.
 
 ## Test database setup
 
-To test the recognition you need to configure the decoding with the required 
-paramters, in particular, you need to have a language model `<your.lm>`. For 
-more details see [tutoriallm](/wiki/tutoriallm).
+To test the recognition you need to configure the decoding with the required
+paramters, in particular, you need to have a language model `<your.lm>`. For
+more details see the [Building a language model](/wiki/tutoriallm) page.
 
-Create fileids file `test.fileids`:
+Create a *fileids* file `test.fileids`:
 
-```	
+```
 test1
 test2
 ```
 
-Create transcription file `test.transcription`:
+Create a transcription file `test.transcription`:
 
-```	
+```
 some text (test1)
 some text (test2)
 ```
 
-Put the audio files in wav folder. Make sure those files have proper format and 
-sample rate.
+Put the audio files in the *wav* folder. Make sure those files have a proper
+format and sample rate.
 
-```	
-wav/test1.wav
-wav/test2.wav
+```
+└─ wav
+   ├─ test1.wav
+   └─ test2.wav
 ```
 
 ## Running the test
 
-Now, let's run the decoder:
+Now, let’s run the decoder:
 
-```	
+```bash
 pocketsphinx_batch \
  -adcin yes \
  -cepdir wav \
  -cepext .wav \
  -ctl test.fileids \
- -lm `<your.lm, for example en-us.lm.bin from pocketsphinx>` \
- -dict `<your.dic, for example cmudict-en-us.dict from pocketsphinx>` \
- -hmm `<your_hmm, for example en-us>` \
+ -lm `<your.lm>` \    # for example en-us.lm.bin from pocketsphinx
+ -dict `<your.dic>` \ # for example cmudict-en-us.dict from pocketsphinx
+ -hmm `<your_hmm>` \  # for example en-us
  -hyp test.hyp
 
 word_align.pl test.transcription test.hyp
 ```
 
-`word_align.pl` script is a part of sphinxtrain distribution
+The `word_align.pl` script is a part of sphinxtrain distribution.
 
-Make sure to add `-samprate 8000` to the above command if you are
-decoding 8kHz files!
+Make sure to add the `-samprate 8000` option to the above command if you are
+decoding 8 kHz files!
 
-The script word-align.pl from Sphinxtrain will report you the exact error rate 
-which you can use to decide if adaptation worked for you. It will look 
-something like:
+The script `word-align.pl` from Sphinxtrain will report you the exact error rate
+which you can use to decide if the adaptation worked for you. It will look
+something like this:
 
-```	
+```
 TOTAL Words: 773 Correct: 669 Errors: 121
 TOTAL Percent correct = 86.55% Error = 15.65% Accuracy = 84.35%
 TOTAL Insertions: 17 Deletions: 11 Substitutions: 93
 ```
 
-To see the speed of the decoding, check pocketsphinx logs, it should look like 
+To see the speed of the decoding, check pocketsphinx logs, it should look like
 this:
 
-```	
+```
 INFO: batch.c(761): 2484510: 9.09 seconds speech, 0.25 seconds CPU, 0.25 seconds wall
 INFO: batch.c(763): 2484510: 0.03 xRT (CPU), 0.03 xRT (elapsed)
 ```
 
-here `0.03xRT` is a decoding speed.
+with `0.03 xRT` being a decoding speed ("0.03 times the recording time").
+
+<span class="post-bottom-nav">
+  [Training an acoustic model](/wiki/tutorialam)
+  [Back to the Index](/wiki/tutorial)
+</span>


### PR DESCRIPTION
Addresses #31.

First of all: @nshmyrev, it’s a really great tutorial with loads of insights! I hope it gets even nicer to read and easier to understand with my corrections:

* Improves the language in the tutorial texts
* Introduces a bottom navigation that is used on the tutorial pages to easily go to the previous/next page: 
![image](https://user-images.githubusercontent.com/1781347/30485878-0924b510-9a2f-11e7-8b09-728f9fb9ba34.png)
* Adds a table of contents to the header of each tutorial page
* Removes duplicate headlines (only uses the post’s title and skips the h1 markdown heading)
* Weakens some verbalisations, where I thought they might maybe be a bit too "offensive" or the user is unnecessarily "shouted" at (e.g. some ALL UPPER CASE PARTS).

I wasn’t entirely sure how to deal with the lib/projects names. Sometimes, if it is written about the lib as you would call it in the terminal the texts use lowercase names, such as `sphinxtrain`, `pocketsphinx`. Other sentences use the CamelCased names, like `SphinxTrain`, `PocketSphinx`. Is there any kind of guideline when to use which spelling?