### PR TITLE
Add missing parenthesis in code example

### DIFF
--- a/wiki/gstreamer.md
+++ b/wiki/gstreamer.md
@@ -405,7 +405,7 @@ class DemoApp(object):
             self.pipeline.set_state(gst.State.PAUSED)
             self.button.set_active(False)
         elif msg.get_structure().get_value('hypothesis'):
-            self.partial_result(msg.get_structure().get_value('hypothesis')
+            self.partial_result(msg.get_structure().get_value('hypothesis'))
 
     def partial_result(self, hyp):
         """Delete any previous selection, insert text and select it."""


### PR DESCRIPTION
Example didn't work, lacked a closing parenthesis. Doesn't work after fixing that, though, either.... (but not due to any syntax errors, at least).