### PR TITLE
updated/removed dead links, fixed formatting, fixed typos

### DIFF
--- a/wiki/sphinxinaction.md
+++ b/wiki/sphinxinaction.md
@@ -1,138 +1,58 @@
 ---
-layout: page 
-tile: The following projects use Sphinx 
+layout: page
+title: The following projects use Sphinx
 ---
 
 **Know any other projects that use Sphinx? Please add them!**
+
 ## Telephony
 
+*  [Freeswitch](http://www.freeswitch.org): Asterisk alternative.  It uses pocketsphinx to offer speech recognition.
 
-*  [Cairo](http://www.speechforge.org/): Cairo provides an enterprise grade, 
-Media Resource Control Protocol Version 2 (MRCPv2) compliant speech server 
-solution utilizing sphinx 4.
+*  [jvoicexml](http://jvoicexml.sourceforge.net): Free VoiceXML interpreter for Java with an open architecture for custom extensions.
 
-*  [Asterisk plugin](http://scribblej.com/svn/): Integrates pocketsphinx into 
-Asterisk.
-
-*  [Freeswitch](http://www.freeswitch.org): Asterisk alternative.  It uses 
-pocketsphinx to offer speech recognition.
-
-*  [jvoicexml](http://jvoicexml.sourceforge.net): Free VoiceXML interpreter for 
-Java with an open architecture for custom extensions.
-
-*  [Zanzibar](http://www.spokentech.org/openivr/index.html): Zanzibar OpenIVR 
-is a complete, standards based, open  source IVR.
-
-*  [ UniMRCP](http://code.google.com/p/unimrcp/ ): open source MRCP 
-implementation.
+*  [UniMRCP](https://github.com/unispeech/unimrcp): open source MRCP implementation.
 
 ## Desktop Voice assistants
 
+*  [Jasper](http://jasperproject.github.io): Personal assistant for Raspberry Pi.
 
-*  [ Jasper ](http://jasperproject.github.io ): Personal assistant for 
-Raspberry Pi.
+*  [perlbox](http://perlbox.sourceforge.net/): Provides voice solutions for Linux and Unix desktop control.
 
-*  [Gnome-Voice-Control](http://live.gnome.org/GnomeVoiceControl): 
-Gnome-Voice-Control is a dialogue system to control the GNOME Desktop.
+*  [Speech Recognizer](http://www.lumenvox.com): A full blown high concurrency C++ Flash Streaming Server running on windows and *nix.  Uses pocketsphinx for speech recognition.
 
-*  [ perlbox](http://perlbox.sourceforge.net/ ): Provides voice solutions for 
-Linux and Unix desktop control.
+*  [Arabisc](http://sourceforge.net/projects/arabisc/): Arabic acoustic model.
 
-*  [ Mammoth](http://www.lumenvox.com ): Becoming a full blown high concurrency 
-C++ Flash Streaming Server running on windows and *nix.  Uses pocketsphinx for 
-speech recognition.
+*  [Voicekey](http://sourceforge.net/projects/voicekey/): voice-controlled keyboard for GNU/Linux.
 
-*  [ 
-Twitterkiller](http://dingoskidneys.com/cgi-bin/hgwebdir.cgi/twitterkiller/ ) - 
-TWiT podcast improver, filters advertizing
+*  [Misterhouse](http://sourceforge.net/projects/misterhouse/): an open source home automation program.
 
-*  [ Arabisc ](http://sourceforge.net/projects/arabisc/ ) - Arabic acoustic 
-model.
+*  [In Verbis Virtus](http://www.inverbisvirtus.com/): A fantasy first person game in which you cast spells using your voice.
 
-*  [Voicekey](http://sourceforge.net/projects/voicekey/) -- voice-controlled 
-keyboard for GNU/Linux.
+*  [PocketVox](https://github.com/benoitfragit/pocketVox): Pocketsphinx-based voice control for GNOME
 
-*  
-[SpeechLion](http://brewer123.home.comcast.net/~brewer123/projects/speechlion/) 
--- Desktop control application using Sphinx4 and FreeTTS written in python.
+*  [ILA voice assistant](https://sites.google.com/site/ilavoiceassistant/): ILA voice assistant
 
-*  [ Nightingale ](http://gitorious.org/nightingale ) - Voice Web Browser
+##  Mobile
 
-*  [ Misterhouse](http://sourceforge.net/projects/misterhouse/ ) -- an open 
-source home automation program.
-
-*  [ Vedics ](https://sourceforge.net/projects/vedics/ ) -- Yet another 
-command-and-control specifically for guys from India! Only check if you are 
-Indian from the Punjab!
-
-*  [ Babble Planet ](http://www.babbleplanet.com ) -- A serious game for 
-children to learn spoken English thanks to Sphinx.
-
-*  [ In Verbis Virtus](http://www.inverbisvirtus.com/ ) -- A fantasy first 
-person game in which you cast spells using your voice.
-
-*  [ PocketVox](https://github.com/benoitfragit/pocketVox ) -- 
-Pocketsphinx-based voice control for GNOME
-
-*  [ ILA voice assistant](https://sites.google.com/site/ilavoiceassistant/ ) -- 
-ILA voice assistant
-
-##  Mobile 
-
-*  [ Inimesed ](http://kaljurand.github.com/Inimesed ) -- Android application 
-to deal contacts.
-
-*  [ Vague ](http://kual.knetconnect.com/vague-voice-activated-gui-for-kual) -- 
-Voice extension for Kual on Kindle
+*  [Inimesed](http://kaljurand.github.com/Inimesed): An Android app that lets you search your contacts by voice
 
 ## Other interesting things
 
-
-*  [ rhubarb-lip-sync](https://github.com/DanielSWolf/rhubarb-lip-sync ) - lip 
-sync for animation.
-
-## Transcription
-
-
-*  [ Gaupol ](http://home.gna.org/gaupol ) -- Subtitle editor
+*  [rhubarb-lip-sync](https://github.com/DanielSWolf/rhubarb-lip-sync): lip sync for animation.
 
 ## Development
 
+*  [VocalKit](http://github.com/KingOfBrian/VocalKit): Pocketsphinx wrapper for iPhone
 
-*  [ VocalKit](http://github.com/KingOfBrian/VocalKit) - Pocketsphinx wrapper 
-for iPhone 
+*  [SpeechCloud](http://sourceforge.net/projects/speechcloud/)--  Recognition toolkit for Amazon EC2 using sphinx4.
 
-*  [SpeechCloud](http://sourceforge.net/projects/speechcloud/)--  Recognition 
-toolkit for Amazon EC2 using sphinx4.
+*  [Cycling74](http://cycling74.com/2010/01/08/project35-oprecognize): sphinx4 applied for MaxMSP.
 
-*  [ASTRA - Advanced Sphinx 
-Trainer](http://www.qt-apps.org/content/show.php/ASTRA+-+Advanced+Sphinx+Trainer
-?content=98611): ASTRA is a Free (under GPL v3) project manager for CMU 
-Sphinx-III.
+*  [Ruby Pocketsphinx Server](https://github.com/alumae/ruby-pocketsphinx-server): HTTP server transcribing requests in Ruby
 
-*  [ Cycling74](http://cycling74.com/2010/01/08/project35-oprecognize ) - 
-sphinx4 applied for MaxMSP.
-
-*  [ OpenInterface 
-SphinxSpeech](https://forge.openinterface.org/projects/sphinxspeech/ ) - 
-OpenInterface project using Sphinx.
-
-*  <https://github.com/alumae/ruby-pocketsphinx-server> - HTTP server
-transcribing requests in Ruby
-
-*  <https://github.com/watsonbox/pocketsphinx-ruby> - pocketsphinx Ruby bindings
-created with FFI
-
-## Art Installations
-
-
-*  [ Chatter ](http://lilwondermat.com/chatter/ ) - Two computers talk with 
-Twitter
-
-*  [ Listening Post ](http://www.deweyhagborg.com/listeningPost/ ) - Listens 
-for talks in public places
+*  [Pocketsphinx Ruby](https://github.com/watsonbox/pocketsphinx-ruby): pocketsphinx Ruby bindings created with FFI
 
 ## Interoperation with other engines
 
-<http://sourceforge.net/projects/srmc/> Speech Recognition Model Conversion (See
-also htk2s3conv in our sources).
+* [Speech Recognition Model Converter](http://sourceforge.net/projects/srmc/): A universal speech recognition model converter (USMC). _(See also htk2s3conv in our sources)_


### PR DESCRIPTION
## Fixed several items
- removed any dead links (result: 404)
- updated links / description for working links
- removed category headings with no children
- brought all descriptions onto a single line of text
- fixed formatting inconsistencies on markdown links (extra spaces, mostly)
- added titles to links that did not have one, based on link content
- attempted to preserve original formatting otherwise